### PR TITLE
l2tp_broker.py.patch: include port also for session.pre-down

### DIFF
--- a/gateways_l2tp/files/l2tp_broker.py.patch
+++ b/gateways_l2tp/files/l2tp_broker.py.patch
@@ -1,7 +1,14 @@
-index 3abb098..f6f7b4a 100644
+index be402cb..7e9ccd9 100644
 --- a/broker/l2tp_broker.py
 +++ b/broker/l2tp_broker.py
-@@ -635,7 +635,7 @@ class Tunnel(gevent.Greenlet):
+@@ -629,13 +629,13 @@ class Tunnel(gevent.Greenlet):
+     for session in self.sessions.values():
+       # Invoke any pre-down hooks
+       self.manager.hook('session.pre-down', self.id, session.id, session.name, self.pmtu, self.endpoint[0],
+-        self.endpoint[1], self.port, self.uuid)
++        self.endpoint[1], self.port, self.uuid, self.external_port)
+ 
+       self.manager.netlink.session_delete(self.id, session.id)
  
        # Invoke any down hooks
        self.manager.hook('session.down', self.id, session.id, session.name, self.pmtu, self.endpoint[0],


### PR DESCRIPTION
Bislang wurde nur session.down erweitert welches aber gar nicht benutzt wird.
Dieser PR erweitert session.pre-down und behebt Issue #17.
