### PR TITLE
HopGlass-Server

### DIFF
--- a/services_hopglass-server/handlers/main.yml
+++ b/services_hopglass-server/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: install hopglass server service
+  service: name=hopglass-server@default state=started enabled=yes

--- a/services_hopglass-server/tasks/main.yml
+++ b/services_hopglass-server/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Installationsskript herunterladen 
+  get_url: 
+    url: https://github.com/hopglass/hopglass-server/raw/master/scripts/bootstrap.sh
+    dest: /tmp/bootstrap.sh
+
+- name: python-pip installieren
+  apt: 
+    name: python-pip
+    update_cache: yes
+    
+- name: pip-Modul pexpect installieren, um das Installationsskript nutzen zu können
+  pip:
+    name: pexpect
+
+- name: HopGlass-Server installieren
+  expect:
+    command: bash /tmp/bootstrap.sh
+    responses:
+      'Do you want to continue\?': 'y'
+      'Where do you want to install the HopGlass Server\?': '/opt/hopglass'
+
+- name: Installationsskript entfernen
+  file: path=/tmp/bootstrap.sh state=absent
+
+- name: Konfiguration kopieren, Service installieren und starten
+  template: 
+    src: config.json.j2 
+    dest: /etc/hopglass-server/default/config.json
+    owner: hopglass
+    group: hopglass
+    mode: 0644
+  notify: install hopglass server service

--- a/services_hopglass-server/templates/config.json.j2
+++ b/services_hopglass-server/templates/config.json.j2
@@ -1,0 +1,40 @@
+# This file is managed by ansible, don't make changes here - they will be overwritten.
+
+{
+  "receiver": {
+    "receivers": [
+      { "module": "announced",
+        "config": {
+          "interval": {
+            "statistics": 60,
+            "nodeinfo": 500
+          }
+        }
+      },
+      { "module": "aliases",
+        "config": {
+          "file": "./aliases.json"
+        },
+        "overlay": true
+      }
+    ],
+    "ifaces": [
+{% for domaene in domaenen|dictsort %}
+      "bat{{domaene[0]}}"{% if not loop.last %},{% endif %}
+
+{% endfor %}
+    ],
+    "storage": {
+      "file": "./raw.json"
+    },
+    "purge": {
+      "maxAge": 14
+    }
+  },
+  "provider": {
+    "offlineTime": 900
+  },
+  "webserver": {
+    "port": 4000
+  }
+}


### PR DESCRIPTION
Damit lässt sich der HopGlass-Server installieren. Etwas Feinschliff ist vielleicht noch nötig, aber grundsätzlich funktioniert es so.

Mögliche Abfragen siehe [hier](https://github.com/hopglass/hopglass-server) unter "Possible webserver queries".