### PR TITLE
Falls HopGlass-Server bereits läuft neu starten

### DIFF
--- a/services_hopglass-server/handlers/main.yml
+++ b/services_hopglass-server/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: install hopglass server service
-  service: name=hopglass-server@default state=started enabled=yes
+  service: name=hopglass-server@default state=restarted enabled=yes


### PR DESCRIPTION
Mit meinem bisherigen Script wird der HopGlass-Server nicht neu gestartet, falls er bereits läuft. Hiermit wird das behoben.