### PR TITLE
{{ansible_managed}}-Macro verwenden

### DIFF
--- a/backbone_gre_ffms/templates/gre_interbackbone.j2
+++ b/backbone_gre_ffms/templates/gre_interbackbone.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 {% for host in groups['gateways']+groups['domaene-06'] %}
 {% if host != inventory_hostname %}
 auto bck-{{host}}

--- a/bird/templates/bird.conf.j2
+++ b/bird/templates/bird.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 log syslog all;
 router id {{ vm_id }};
 

--- a/bird/templates/bird6.conf.j2
+++ b/bird/templates/bird6.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };
 router id {{ vm_id }};
 

--- a/collectd/templates/collectd.conf.j2
+++ b/collectd/templates/collectd.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # Config file for collectd(1).
 #
 # Some plugins need additional configuration and are disabled by default.

--- a/collectd/templates/collection.conf.j2
+++ b/collectd/templates/collection.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 datadir: "/var/lib/collectd/rrd/"
 libdir: "/usr/lib/collectd/"
 

--- a/collectd/templates/fastd.py.j2
+++ b/collectd/templates/fastd.py.j2
@@ -1,6 +1,7 @@
 #!/usr/bin/python
-# This file is managed by ansible, don't make changes here - they will be overwritten.
-#
+
+# {{ ansible_managed }}
+
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/collectd/templates/filters.conf.j2
+++ b/collectd/templates/filters.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # Filter configuration for collectd(1).
 #
 # See the section "FILTER CONFIGURATION" in collectd.conf(5) for details.

--- a/collectd/templates/thresholds.conf.j2
+++ b/collectd/templates/thresholds.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # Threshold configuration for collectd(1).
 #
 # See the section "THRESHOLD CONFIGURATION" in collectd.conf(5) for details.

--- a/dhcp/templates/dhcpd.conf.j2
+++ b/dhcp/templates/dhcpd.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 default-lease-time {{dhcp_global.lease_default}};
 max-lease-time {{dhcp_global.lease_max}};
 

--- a/dienste_bind/templates/named.conf.j2
+++ b/dienste_bind/templates/named.conf.j2
@@ -1,4 +1,5 @@
-// This file is managed by ansible, don't make changes here - they will be overwritten.
+// {{ ansible_managed }}
+
 // This is the primary configuration file for the BIND DNS server named.
 //
 // Please read /usr/share/doc/bind9/README.Debian.gz for information on the 

--- a/fastd/templates/dummy.j2
+++ b/fastd/templates/dummy.j2
@@ -1,3 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # A dummy peer is needed so fastd will start 
 key "THIS-IS-A-DUMMY";

--- a/fastd/templates/fastd.conf.j2
+++ b/fastd/templates/fastd.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # Bind to a fixed address and port, IPv4 and IPv6
 bind {{ansible_eth0.ipv4.address}}:{{fastd.port}} interface "eth0";
 

--- a/fastd/templates/public.key.j2
+++ b/fastd/templates/public.key.j2
@@ -1,2 +1,3 @@
 # {{ ansible_managed }} 
+
 key "{{fastd_key_generated.stdout_lines[1]|replace("Public: ","")}}";

--- a/fastd/templates/secret.key.j2
+++ b/fastd/templates/secret.key.j2
@@ -1,2 +1,3 @@
 # {{ ansible_managed }} 
+
 secret "{{fastd_key_generated.stdout_lines[0]|replace("Secret: ","")}}";

--- a/fastd/templates/verify.sh.j2
+++ b/fastd/templates/verify.sh.j2
@@ -1,5 +1,6 @@
 #!/bin/bash
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 # Implementierung einer Fastd Blacklist 
 # Das Script wird aus Fastd beim Aufbau einer Verbidung aufgerufen
 # Die geblockten Keys werden in der Datei blacklist aufgeführt

--- a/gateways_batman/tasks/main.yml
+++ b/gateways_batman/tasks/main.yml
@@ -13,7 +13,11 @@
   when: domaenenliste is defined
 
 - name: Routingtabelle 42 auch ffnet nennen
-  lineinfile: dest="/etc/iproute2/rt_tables" line="42   ffnet"
+  blockinfile:
+    path: "/etc/iproute2/rt_tables"
+    marker: "# {mark} Ansible managed block"
+    block: |
+      42   ffnet
   when: domaenenliste is defined
 
 - name: Drei Sekunden nach Kernelpanik automatisch neu starten

--- a/gateways_batman/templates/batman.j2
+++ b/gateways_batman/templates/batman.j2
@@ -1,4 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
 
 # Batman Interface 
 # - Erstellt das virtuelle Interface fuer das Batman-Modul und bindet dieses an die Netzwerkbruecke

--- a/gateways_bind/templates/db.ffnet.j2
+++ b/gateways_bind/templates/db.ffnet.j2
@@ -1,3 +1,5 @@
+; {{ ansible_managed }}
+
 ; zonefile for {{freifunk.kurzname}}. for domaene-{{item}}
 $TTL    86400
 @       IN      SOA     {{bind_zonemaster.server}}. {{bind_zonemaster.email | regex_replace('@', '.') }}. (

--- a/gateways_bind/templates/named.conf.ffnet.j2
+++ b/gateways_bind/templates/named.conf.ffnet.j2
@@ -1,6 +1,8 @@
+# {{ ansible_managed }}
+
 {% if domaenenliste is defined %}
 {% for domaene in domaenenliste|dictsort -%}
-#view for (broadcast-)domain domaene-{{domaene[0]}}   
+# view for (broadcast-)domain domaene-{{domaene[0]}}   
 view "domaene-{{domaene[0]}}" {
         match-clients {
                 {{domaenen[domaene[0]].ffv4_network}};

--- a/gateways_bind/templates/named.conf.j2
+++ b/gateways_bind/templates/named.conf.j2
@@ -1,4 +1,5 @@
-// This file is managed by ansible, don't make changes here - they will be overwritten.
+// {{ ansible_managed }}
+
 // This is the primary configuration file for the BIND DNS server named.
 //
 // Please read /usr/share/doc/bind9/README.Debian.gz for information on the 

--- a/gateways_bind/templates/named.conf.local.j2
+++ b/gateways_bind/templates/named.conf.local.j2
@@ -1,1 +1,3 @@
+// {{ ansible_managed }}
+
 include "/etc/bind/zones.rfc1918";

--- a/gateways_bind/templates/named.conf.log.j2
+++ b/gateways_bind/templates/named.conf.log.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 logging{
   channel default_log {
     file "/var/log/named/bind.log";

--- a/gateways_bind/templates/named.conf.options.j2
+++ b/gateways_bind/templates/named.conf.options.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 options {
         directory "/var/cache/bind";
 

--- a/gateways_bind/templates/named.conf.tld.j2
+++ b/gateways_bind/templates/named.conf.tld.j2
@@ -1,3 +1,5 @@
+// {{ ansible_managed }}
+
 {% for domain in domains %}
 zone "{{domain}}" IN {
 	type slave;

--- a/gateways_dhcp/templates/dhcpd.conf.j2
+++ b/gateways_dhcp/templates/dhcpd.conf.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 default-lease-time {{dhcp_global.lease_default}};
 max-lease-time {{dhcp_global.lease_max}};
 

--- a/gateways_gre_upstream/templates/gre_upstream.j2
+++ b/gateways_gre_upstream/templates/gre_upstream.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 {% if ffrl_tun is defined %}
 {% for tun in ffrl_tun %}
 

--- a/gateways_gre_upstream/templates/lo.j2
+++ b/gateways_gre_upstream/templates/lo.j2
@@ -1,3 +1,5 @@
+# {{ ansible_managed }}
+
 auto lo
 iface lo inet loopback
 {% if ffrl_tun is defined and ffrl_nat_ip is defined %}

--- a/gateways_gretap/templates/gretap.j2
+++ b/gateways_gretap/templates/gretap.j2
@@ -1,4 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
 {% set indexer = [0] %}
 {% set hosts = [] %}
 {% for domaene in domaenenliste|dictsort %}

--- a/gateways_l2tp/templates/l2tp_bridge.j2
+++ b/gateways_l2tp/templates/l2tp_bridge.j2
@@ -1,4 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
 
 {% for item in domaenenliste|dictsort %}
 auto br{{item[0]}}

--- a/gateways_l2tp/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp/templates/l2tp_broker.cfg.j2
@@ -1,6 +1,6 @@
 [broker]
 ; IP address the broker will listen and accept tunnels on
-address={{ansible_eth0.ipv4.address}}
+address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
 {% if tunneldigger.instance_per_domain == True %}
 port={{20000 + (item.key | int)}}

--- a/gateways_l2tp_slovenija/templates/l2tp_bridge.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_bridge.j2
@@ -1,4 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
 
 {% for item in domaenenliste|dictsort %}
 auto br{{item[0]}}

--- a/icinga/templates/api.conf
+++ b/icinga/templates/api.conf
@@ -1,5 +1,5 @@
 /**
- * This config is managed by ansible, do not edit manualy ! 
+ * {{ ansible_managed }} 
  *
  * The API listener is used for distributed monitoring setups.
  */

--- a/iptables/templates/rules.v4.j2
+++ b/iptables/templates/rules.v4.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]

--- a/iptables/templates/rules.v6.j2
+++ b/iptables/templates/rules.v6.j2
@@ -1,4 +1,5 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
+
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]

--- a/mapserver_interfaces/templates/batman.j2
+++ b/mapserver_interfaces/templates/batman.j2
@@ -1,4 +1,4 @@
-# This file is managed by ansible, don't make changes here - they will be overwritten.
+# {{ ansible_managed }}
 
 {% set indexer = [0] -%}
 {% for domaene in domaenen|dictsort %}

--- a/motd/templates/99-custom.j2
+++ b/motd/templates/99-custom.j2
@@ -1,4 +1,6 @@
 #!/bin/sh
+# {{ ansible_managed }}
+
 cat << 'EOF'
  This system is managed by Ansible.
 


### PR DESCRIPTION
Konfigurationsdateien als von Ansible verwaltet markieren.
Dazu in Templates oben als Kommentar "{{ ansible_managed }}" eingefügt, wo schon ein Freitextkommentar stand wurde der ersetzt.
