### PR TITLE
New role batman_install to install batctl from Debian repository

### DIFF
--- a/batman_install/tasks/main.yml
+++ b/batman_install/tasks/main.yml
@@ -1,0 +1,4 @@
+- name: batctl-Paket installieren
+  apt:
+    pkg: ['batctl']
+    state: present


### PR DESCRIPTION
Rolle "batman_install" hinzugefügt, die batctl aus dem Debian-Repository installiert.

Kann Alternative zur Rolle "batman_build" verwendet werden. Wenn man Batman nicht selber baut fehlt ansonsten batctl.
