### PR TITLE
gateways_bind: systemd-service-Dateien des Debian-Pakets nicht überschreiben

### DIFF
--- a/gateways_bind/files/bind9.service
+++ b/gateways_bind/files/bind9.service
@@ -1,13 +1,2 @@
-[Unit]
-Description=BIND Domain Name Server
-Documentation=man:named(8)
-After=network.target
-
 [Service]
-ExecStart=/usr/sbin/named -f -u bind
-ExecReload=/usr/sbin/rndc reload
-ExecStop=/usr/sbin/rndc stop
 Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target

--- a/gateways_bind/tasks/main.yml
+++ b/gateways_bind/tasks/main.yml
@@ -57,7 +57,15 @@
   with_items: "{{domaenenliste | default([])}}"
   when: "{{domaenenliste is defined}}"
 
-- name: bind9.service kopieren
-  copy: src=bind9.service dest=/lib/systemd/system/bind9.service
+- name: create folder for bind9.service file
+  file: path=/etc/systemd/system/bind9.service.d state=directory mode=0755
+
+- name: copy bind9.service
+  copy: src=bind9.service dest=/etc/systemd/system/bind9.service.d/override.conf
   notify:
     - restart bind9
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes
+


### PR DESCRIPTION
Stattdessen Änderungen per "override" machen.
Hält den Pflegeaufwand niedriger.