### PR TITLE
bird: systemd-service-Dateien des Debian-Pakets nicht überschreiben

### DIFF
--- a/bird/files/bird.service
+++ b/bird/files/bird.service
@@ -1,14 +1,2 @@
-[Unit]
-Description=BIRD Internet Routing Daemon (IPv4)
-After=network.target
-
 [Service]
-EnvironmentFile=/etc/bird/envvars
-ExecStartPre=/usr/lib/bird/prepare-environment
-ExecStartPre=/usr/sbin/bird -p
-ExecReload=/usr/sbin/birdc configure
-ExecStart=/usr/sbin/bird -f -u $BIRD_RUN_USER -g $BIRD_RUN_GROUP $BIRD_ARGS
 Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target

--- a/bird/files/bird6.service
+++ b/bird/files/bird6.service
@@ -1,14 +1,2 @@
-[Unit]
-Description=BIRD Internet Routing Daemon (IPv6)
-After=network.target
-
 [Service]
-EnvironmentFile=/etc/bird/envvars
-ExecStartPre=/usr/lib/bird/prepare-environment
-ExecStartPre=/usr/sbin/bird6 -p
-ExecReload=/usr/sbin/birdc6 configure
-ExecStart=/usr/sbin/bird6 -f -u $BIRD_RUN_USER -g $BIRD_RUN_GROUP $BIRD_ARGS
 Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target

--- a/bird/tasks/main.yml
+++ b/bird/tasks/main.yml
@@ -50,19 +50,29 @@
   notify:
     - configure bird6
 
+- name: create folder for bird.service file
+  file: path=/etc/systemd/system/bird.service.d state=directory mode=0755
+
 - name: bird.service kopieren
   copy: 
     src: bird.service
-    dest: /lib/systemd/system/bird.service
+    dest: /etc/systemd/system/bird.service.d/override.conf
   notify:
     - configure bird
+
+- name: create folder for bird6.service file
+  file: path=/etc/systemd/system/bird6.service.d state=directory mode=0755
 
 - name: bird6.service kopieren
   copy: 
     src: bird6.service
-    dest: /lib/systemd/system/bird6.service
+    dest: /etc/systemd/system/bird6.service.d/override.conf
   notify:
     - configure bird6
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes
 
 - name: activate and start bird
   service:


### PR DESCRIPTION
Stattdessen Änderungen per "override" machen.
Hält den Pflegeaufwand niedriger.