### PR TITLE
gateways_dhcp: Systemd-Service-Datei für dhcpd-tmfs verschieben

### DIFF
--- a/gateways_dhcp/tasks/main.yml
+++ b/gateways_dhcp/tasks/main.yml
@@ -23,13 +23,13 @@
   template: src=closeramdisk.j2 dest=/usr/src/dhcpd/closeramdisk mode="a+x"
 
 - name: tmpfs systemd service for dhcpd
-  template: src=dhcpd-tmpfs.service.j2 dest=/lib/systemd/system/dhcpd-tmpfs.service
+  template: src=dhcpd-tmpfs.service.j2 dest=/etc/systemd/system/dhcpd-tmpfs.service
 
 - name: enable dhcpd-tmpfs service
   service: name=dhcpd-tmpfs enabled=yes state=started
 
 - name: install isc-dhcp-server
-  apt: pkg=isc-dhcp-server state=installed
+  apt: pkg=isc-dhcp-server state=present
 
 - name: create dhcp defaults 
   template: src=isc-dhcp-server.j2 dest=/etc/default/isc-dhcp-server


### PR DESCRIPTION
Sollte nicht unter /lib/systemd/system liegen sondern unter /etc/systemd/system