### PR TITLE
common: logrotate-Konfiguration aufteilen

### DIFF
--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -123,6 +123,36 @@
     dest: /etc/logrotate.conf
   when: logrotate is defined
 
+- name: Logrotate konfigurieren für btmp
+  template:
+    src: logrotate-btmp.j2
+    dest: /etc/logrotate.d/logrotate-btmp
+  when: logrotate is defined
+
+- name: Logrotate konfigurieren für wtmp
+  template:
+    src: logrotate-wtmp.j2
+    dest: /etc/logrotate.d/logrotate-wtmp
+  when: logrotate is defined
+
+- name: Logrotate konfigurieren für bind
+  template:
+    src: logrotate-bind.j2
+    dest: /etc/logrotate.d/logrotate-bind
+  when: logrotate is defined and ('gateways' in group_names or 'services' in group_names)
+
+- name: Logrotate konfigurieren für KEA-dhcpd4
+  template:
+    src: logrotate-kea-dhcp4.j2
+    dest: /etc/logrotate.d/logrotate-kea-dhcp4
+  when: logrotate is defined and ('dhcp_type' in hostvars[inventory_hostname] and dhcp_type == 'kea')
+
+- name: Logrotate konfigurieren für Tunneldigger-Broker
+  template:
+    src: logrotate-tunneldigger-broker.j2
+    dest: /etc/logrotate.d/logrotate-tunneldigger-broker
+  when: logrotate is defined and ('gateways' in group_names)
+
 - name: Setze Timeout für das stopen von Interfaces
   lineinfile:
     dest: /lib/systemd/system/networking.service.d/network-pre.conf

--- a/common/templates/logrotate-bind.j2
+++ b/common/templates/logrotate-bind.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+/var/log/named/bind.log {
+    {{logrotate.cycle}}
+    rotate {{logrotate.count}}
+    copytruncate
+}

--- a/common/templates/logrotate-btmp.j2
+++ b/common/templates/logrotate-btmp.j2
@@ -1,0 +1,8 @@
+# {{ ansible_managed }}
+
+/var/log/btmp {
+    missingok
+    {{logrotate.cycle}}
+    create 0660 root utmp
+    rotate {{logrotate.count}}
+}

--- a/common/templates/logrotate-kea-dhcp4.j2
+++ b/common/templates/logrotate-kea-dhcp4.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+/var/log/kea-dhcp4.log {
+    {{logrotate.cycle}}
+    rotate {{logrotate.count}}
+    copytruncate
+}

--- a/common/templates/logrotate-tunneldigger-broker.j2
+++ b/common/templates/logrotate-tunneldigger-broker.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+{% if 'gateways' in group_names %}
+/var/log/tunneldigger-broker.log {
+    {{logrotate.cycle}}
+    rotate {{logrotate.count}}
+    copytruncate
+}
+{% endif %}

--- a/common/templates/logrotate-wtmp.j2
+++ b/common/templates/logrotate-wtmp.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+
+# no packages own wtmp, or btmp -- we'll rotate them here
+/var/log/wtmp {
+    missingok
+    {{logrotate.cycle}}
+    create 0664 root utmp
+    rotate {{logrotate.count}}
+}

--- a/common/templates/logrotate.conf.j2
+++ b/common/templates/logrotate.conf.j2
@@ -1,6 +1,10 @@
+# {{ ansible_managed }}
+
 # see "man logrotate" for details
+# rotate log files this often
 {{logrotate.cycle}}
 
+# keep X weeks worth of backlogs
 rotate {{logrotate.count}}
 
 # create new (empty) log files after rotating old ones
@@ -12,41 +16,5 @@ create
 # packages drop log rotation information into this directory
 include /etc/logrotate.d
 
-# no packages own wtmp, or btmp -- we'll rotate them here
-/var/log/wtmp {
-    missingok
-    monthly
-    create 0664 root utmp
-    rotate 1
-}
+# system-specific logs may be also be configured here.
 
-/var/log/btmp {
-    missingok
-    monthly
-    create 0660 root utmp
-    rotate 1
-}
-{% if 'gateways' in group_names or 'services' in group_names %}
-/var/log/named/bind.log {
-    {{logrotate.cycle}}
-    rotate {{logrotate.count}}
-    copytruncate
-}
-{% endif %}
-
-{% if 'gateways' in group_names %}
-/var/log/tunneldigger-broker.log {
-    {{logrotate.cycle}}
-    rotate {{logrotate.count}}
-    copytruncate
-}
-{% endif %}
-
-# system-specific logs may be configured here
-{% if 'dhcp_type' in hostvars[inventory_hostname] and dhcp_type == 'kea' %}
-/var/log/kea-dhcp4.log {
-    {{logrotate.cycle}}
-    rotate {{logrotate.count}}
-    copytruncate
-}
-{% endif %}


### PR DESCRIPTION
Globale Einstellungen in /etc/logrotate.conf durchführen
Einstellungen für einzelne Logfiles mit separaten Konfigurationsdateien unter /etc/logrotate.d machen
