### PR TITLE
Sysctl-Einstellungen vereinheitlichen

### DIFF
--- a/gateways_batman/tasks/main.yml
+++ b/gateways_batman/tasks/main.yml
@@ -17,5 +17,5 @@
   when: domaenenliste is defined
 
 - name: Drei Sekunden nach Kernelpanik automatisch neu starten
-  sysctl: name="kernel.panic" value=3 sysctl_set=yes state=present reload=yes
+  sysctl: name="kernel.panic" value=3 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-kernelpanic.conf
   when: domaenenliste is defined

--- a/ip_forwarding/tasks/main.yml
+++ b/ip_forwarding/tasks/main.yml
@@ -1,11 +1,11 @@
-- name: IPv4 Paketweiterleitung aktivieren
-  sysctl: name="net.ipv4.conf.all.forwarding" value=1 sysctl_set=yes state=present reload=yes
+- name: IPv4-Paketweiterleitung aktivieren
+  sysctl: name="net.ipv4.conf.all.forwarding" value=1 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-ip_forwarding.conf
 
-- name: IPv6 Paketweiterleitung aktivieren
-  sysctl: name="net.ipv6.conf.all.forwarding" value=1 sysctl_set=yes state=present reload=yes
+- name: IPv6-Paketweiterleitung aktivieren
+  sysctl: name="net.ipv6.conf.all.forwarding" value=1 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-ip_forwarding.conf
 
-- name: sysctl rc_filter default deaktivieren
-  sysctl: name="net.ipv4.conf.default.rp_filter" value=0 sysctl_set=yes state=present reload=yes
+- name: sysctl Reverse-Path-Filter default deaktivieren - Quellroute nicht prüfen
+  sysctl: name="net.ipv4.conf.default.rp_filter" value=0 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-ip_forwarding.conf
 
-- name: sysctl rc_filter all deaktivieren
-  sysctl: name="net.ipv4.conf.all.rp_filter" value=0 sysctl_set=yes state=present reload=yes
+- name: sysctl Reverse-Path-Filter all deaktivieren - Quellroute nicht prüfen
+  sysctl: name="net.ipv4.conf.all.rp_filter" value=0 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-ip_forwarding.conf

--- a/net_netfilter/tasks/main.yml
+++ b/net_netfilter/tasks/main.yml
@@ -14,13 +14,13 @@
   lineinfile: dest=/etc/modules line="nf_conntrack_ipv4"
 
 - name: Set nf_conntrack_max to a higher value
-  sysctl: name="net.netfilter.nf_conntrack_max" value=524288 sysctl_set=yes state=present reload=yes
+  sysctl: name="net.netfilter.nf_conntrack_max" value=524288 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-netfilter.conf
 
 - name: Set nf_conntrack_tcp_timeout_established to 86400 (one day)
-  sysctl: name="net.netfilter.nf_conntrack_tcp_timeout_established" value=86400 sysctl_set=yes state=present reload=yes
+  sysctl: name="net.netfilter.nf_conntrack_tcp_timeout_established" value=86400 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-netfilter.conf
 
 - name: Set nf_conntrack_tcp_timeout_time_wait to 60
-  sysctl: name="net.netfilter.nf_conntrack_tcp_timeout_time_wait" value=60 sysctl_set=yes state=present reload=yes
+  sysctl: name="net.netfilter.nf_conntrack_tcp_timeout_time_wait" value=60 sysctl_set=yes state=present reload=yes sysctl_file=/etc/sysctl.d/ff-netfilter.conf
 
 - name: Get current nf_conntrack hashsize
   shell: "cat /sys/module/nf_conntrack/parameters/hashsize"

--- a/tunearpcache/tasks/main.yml
+++ b/tunearpcache/tasks/main.yml
@@ -2,7 +2,7 @@
 # Einrichtung von IP Forwarding 
 
 - name: deploy tunearpcache.conf
-  template: src=tunearpcache.conf.j2 dest=/etc/sysctl.d/tunearpcache.conf
+  template: src=tunearpcache.conf.j2 dest=/etc/sysctl.d/ff-tunearpcache.conf
   notify:
     - restart sysctl
 


### PR DESCRIPTION
Pro Rolle und Kategorie eine Datei anlegen, die mit "ff-..." beginnt.