### PR TITLE
Anpassungen für Debian 10

### DIFF
--- a/bird/tasks/main.yml
+++ b/bird/tasks/main.yml
@@ -26,7 +26,8 @@
     cache_valid_time: 1800
     state: present
   when: (ansible_distribution == "Ubuntu") or
-        (ansible_distribution == "Debian" and ansible_distribution_major_version == "9")
+        (ansible_distribution == "Debian" and ansible_distribution_major_version == "9") or
+        (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
 
 - name: calculate more specific routes for DHCP pools
   shell: ipcalc {{ domaenenliste[item].dhcp_start }} - {{ domaenenliste[item].dhcp_ende}} | grep -v "deaggregate" | sed -e 's/\(^.*$\)/route \1 via "bat{{item}}";/g'

--- a/fastd/handlers/main.yml
+++ b/fastd/handlers/main.yml
@@ -6,5 +6,5 @@
 - name: restart fastd@vpn
   systemd:
     name: fastd@vpn
-    state: reloaded
+    state: restarted
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"

--- a/fastd/handlers/main.yml
+++ b/fastd/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
 - name: restart fastd
   service: name=fastd state=restarted
-  
+  when: not (ansible_distribution == "Debian" and ansible_distribution_major_version == "10")
+
+- name: restart fastd@vpn
+  systemd:
+    name: fastd@vpn
+    state: reloaded
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"

--- a/fastd/tasks/main.yml
+++ b/fastd/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-# Prüfe Repo-Quelle
-- name: Schlüssel hinzufügen
-  apt_key: keyserver=keyserver.ubuntu.com  id=16EF3F64CB201D9C
-
-- name: set fastd-repo
-  apt_repository: repo='deb http://repo.universe-factory.net/debian/ sid main' state=present
-
 # Fastd-Daemon, Habeged-Daemon
 
 - name: install fastd (vpn daemon) and haveged (entropy daemon)

--- a/fastd/tasks/main.yml
+++ b/fastd/tasks/main.yml
@@ -26,6 +26,7 @@
     creates: /etc/fastd/vpn/secret.key
   notify:
     - restart fastd
+    - restart fastd@vpn
 
 # write public & private key to seperate keyfiles, if new fastd key is generated
 - template: src=secret.key.j2 dest=/etc/fastd/vpn/secret.key owner=root group=root mode=0600
@@ -45,6 +46,7 @@
   template: src=fastd.conf.j2 dest=/etc/fastd/vpn/fastd.conf
   notify:
     - restart fastd
+    - restart fastd@vpn
 
 - name: create verify directory
   file: path=/var/gateway-ffms/fastd/ state=directory
@@ -63,3 +65,11 @@
 - name: status.pl nach /root kopieren
   copy: src=status.pl dest=/root/status.pl owner=root group=root mode=0755
 
+- name: enable fastd
+  systemd:
+    name: fastd@vpn
+    enabled: yes
+    masked: no
+  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "10"
+  notify:
+    - restart fastd@vpn

--- a/gateways_dhcp/templates/isc-dhcp-server.j2
+++ b/gateways_dhcp/templates/isc-dhcp-server.j2
@@ -1,3 +1,21 @@
+# {{ ansible_managed }}
+
+# Defaults for isc-dhcp-server (sourced by /etc/init.d/isc-dhcp-server)
+
+# Path to dhcpd's config file (default: /etc/dhcp/dhcpd.conf).
+#DHCPDv4_CONF=/etc/dhcp/dhcpd.conf
+#DHCPDv6_CONF=/etc/dhcp/dhcpd6.conf
+
+# Path to dhcpd's PID file (default: /var/run/dhcpd.pid).
+#DHCPDv4_PID=/var/run/dhcpd.pid
+#DHCPDv6_PID=/var/run/dhcpd6.pid
+
+# Additional options to start dhcpd with.
+#       Don't use options -cf or -pf here; use DHCPD_CONF/ DHCPD_PID instead
+#OPTIONS=""
+
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-INTERFACES="{% for domaene in domaenenliste|dictsort %}bat{{domaene[0]}} {% endfor %}"
+INTERFACESv4="{% for domaene in domaenenliste|dictsort %}bat{{domaene[0]}} {% endfor %}"
+INTERFACESv6=""
+

--- a/net_netfilter/tasks/main.yml
+++ b/net_netfilter/tasks/main.yml
@@ -12,7 +12,7 @@
   when: ansible_kernel is version_compare('4.19', '<')
 
 - name: Enable nf_conntrack_ipv4 on system startup
- blockinfile:
+  blockinfile:
     path: /etc/modules
     marker: "# {mark} Ansible managed block"
     block: |

--- a/net_netfilter/tasks/main.yml
+++ b/net_netfilter/tasks/main.yml
@@ -9,9 +9,28 @@
 
 - name: Enable nf_conntrack_ipv4 module
   modprobe: name=nf_conntrack_ipv4 state=present
+  when: ansible_kernel is version_compare('4.19', '<')
 
 - name: Enable nf_conntrack_ipv4 on system startup
-  lineinfile: dest=/etc/modules line="nf_conntrack_ipv4"
+ blockinfile:
+    path: /etc/modules
+    marker: "# {mark} Ansible managed block"
+    block: |
+      nf_conntrack_ipv4
+  when: ansible_kernel is version_compare('4.19', '<')
+
+- name: Enable nf_conntrack module
+  modprobe: name=nf_conntrack state=present
+  when: ansible_kernel is version_compare('4.19', '>=')
+
+- name: Enable nf_conntrack on system startup
+  blockinfile:
+    path: /etc/modules
+    marker: "# {mark} Ansible managed block"
+    block: |
+      nf_conntrack
+  when: ansible_kernel is version_compare('4.19', '>=')
+
 
 - name: Set nf_conntrack_max to a higher value
   sysctl: name="net.netfilter.nf_conntrack_max" value=524288 sysctl_set=yes state=present reload=yes

--- a/py_respondd/tasks/main.yml
+++ b/py_respondd/tasks/main.yml
@@ -3,18 +3,27 @@
   apt:
     pkg: ['python3-pip']
     state: present
+  when: not (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
 
 - name: Install dependencies
   apt:
     pkg: ['python3-distutils', 'python3-setuptools', 'python3-dev']
     state: present
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04'
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
+
+- name: Install python dependencies
+  apt:
+    pkg: ['python3-psutil', 'python3-netifaces']
+    state: present
+  when: ansible_distribution == 'Debian' and ansible_distribution_version == '10'
 
 - name: Install python dependencies
   pip: 
     name: ['psutil', 'netifaces']
     state: present
     executable: pip3
+  when: not (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
 
 - name: create systemd files
   template: 


### PR DESCRIPTION
- fastd: muss als systemd-Instanz (fastd@vpn) konfiguriert und gestartet werden.
- isc-dhcp-server: Kleine Konfigurationsänderung
- nf_conntrack_ipv4 vs nf_conntrack_ip: Name des Kernelmoduls hat sich ab Linux 4.19 geändert
- py_respondd: Alles, was zum Bauen benötigt wird, ist im Debian-Repository verfügbar. pip3 ist also unnötig.