### PR TITLE
"eth0" durch Inventory-Variable ersetzen

### DIFF
--- a/fastd/templates/fastd.conf.j2
+++ b/fastd/templates/fastd.conf.j2
@@ -1,12 +1,10 @@
 # This file is managed by ansible, don't make changes here - they will be overwritten.
 # Bind to a fixed address and port, IPv4 and IPv6
-bind {{ansible_eth0.ipv4.address}}:{{fastd.port}} interface "eth0";
+bind {{ansible_default_ipv4.address}}:{{fastd.port}} interface "{{ansible_default_ipv4.interface}}";
 
-{% for v6 in ansible_eth0.ipv6 %}
-{% if v6.scope == 'global' %}
-bind [{{v6.address}}]:{{fastd.port}} interface "eth0";
+{% if ansible_default_ipv6 %}
+bind [{{ansible_default_ipv6.address}}]:{{fastd.port}} interface "{{ansible_default_ipv6.interface}}";
 {% endif %}
-{% endfor %}
 
 # Set the user, fastd will work as
 user "nobody";

--- a/gateways_gretap/templates/gretap.j2
+++ b/gateways_gretap/templates/gretap.j2
@@ -26,7 +26,7 @@ iface t{{domaene[0]}}-{{host}} inet manual
 {% if build_tunnels_over_ipv6_if_available is defined and build_tunnels_over_ipv6_if_available and ipv6 is defined and hostvars[host].ipv6 is defined %}
         pre-up ip link add $IFACE type ip6gretap local {{ipv6}} remote {{hostvars[host].ipv6}} dev {{ansible_default_ipv6.interface}} key {{domaene[0]|int}}
 {% else %}
-        pre-up ip link add $IFACE type gretap local {{ipv4}} remote {{hostvars[host].ipv4}} dev eth0 key {{domaene[0]|int}}
+        pre-up ip link add $IFACE type gretap local {{ipv4}} remote {{hostvars[host].ipv4}} dev {{ansible_default_ipv4.interface}} key {{domaene[0]|int}}
 {% endif %}
         pre-up ip link set dev $IFACE address de:ad:be:ef:{{indexer[0]}}:{{vm_id}}
         pre-up ip link set $IFACE up

--- a/gateways_l2tp/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp/templates/l2tp_broker.cfg.j2
@@ -1,6 +1,6 @@
 [broker]
 ; IP address the broker will listen and accept tunnels on
-address={{ansible_eth0.ipv4.address}}
+address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
 {% if tunneldigger.instance_per_domain == True %}
 port={{20000 + (item.key | int)}}

--- a/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
@@ -1,6 +1,6 @@
 [broker]
 ; IP address the broker will listen and accept tunnels on
-address={{ansible_eth0.ipv4.address}}
+address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
 port={{20000 + (item.key | int)}}
 ; Interface with that IP address

--- a/iptables/templates/rules.v4.j2
+++ b/iptables/templates/rules.v4.j2
@@ -11,7 +11,7 @@ COMMIT
 :OUTPUT ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 {% if ipv4_direkt_ausleiten is defined and ipv4_direkt_ausleiten %}
--A POSTROUTING -o eth0 -j SNAT --to-source {{ ansible_default_ipv4.address }}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -j SNAT --to-source {{ansible_default_ipv4.address}}
 {% elif ffrl_tun is defined and ffrl_nat_ip is defined %}
 -A POSTROUTING -o tun-ffrl+ -j SNAT --to-source {{ffrl_nat_ip | ipaddr('address')}}
 {% elif ffnw_tun is defined and ffnw_nat_ip is defined %}

--- a/mapserver_interfaces/templates/batman.j2
+++ b/mapserver_interfaces/templates/batman.j2
@@ -52,7 +52,7 @@ iface t{{domaene[0]}}-{{ host }} inet manual
 {% if build_tunnels_over_ipv6_if_available is defined and build_tunnels_over_ipv6_if_available and ipv6 is defined and hostvars[host].ipv6 is defined %}
         pre-up ip link add $IFACE type ip6gretap local {{ipv6}} remote {{hostvars[host].ipv6}} dev {{ansible_default_ipv6.interface}} key {{domaene[0]|int}}
 {% else %}
-        pre-up ip link add $IFACE type gretap local {{ansible_default_ipv4.address}} remote {{hostvars[host].ipv4}} dev eth0 key {{domaene[0]|int}}
+        pre-up ip link add $IFACE type gretap local {{ansible_default_ipv4.address}} remote {{hostvars[host].ipv4}} dev {{ansible_default_ipv4.interface}} key {{domaene[0]|int}}
 {% endif %}
         pre-up ip link set dev $IFACE address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{server_id}}
         pre-up ip link set $IFACE up
@@ -65,7 +65,7 @@ iface t{{domaene[0]}}-{{ host }} inet manual
 {% if indexer.append(indexer.pop() + 1) %}{% endif %}{# increment indexer by 1 #}
 auto tap-{{ host }}
 iface tap-{{ host }} inet manual
-        pre-up ip link add $IFACE type gretap local {{ansible_default_ipv4.address}} remote {{hostvars[host].ansible_ssh_host}} dev eth0
+        pre-up ip link add $IFACE type gretap local {{ansible_default_ipv4.address}} remote {{hostvars[host].ansible_ssh_host}} dev {{ansible_default_ipv4.interface}} 
         pre-up ip link set dev $IFACE address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{server_id}}
         pre-up ip link set $IFACE up
         post-up batctl -m bat{{domaene[0]}} if add $IFACE ||:

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -13,7 +13,7 @@ command[check_speedtest-cli-50]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -
 command[check_speedtest-cli-100]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -w 100 -c 50 -W 10 -C 5 -p -s 4193
 
 # Bandwith
-#command[check_bandwidth]=/usr/lib/nagios/plugins/check_bandwidth rx 60 {{ansible_default_ipv4.interface}} bw
+#command[check_bandwidth]=/usr/lib/nagios/plugins/check_bandwidth rx 60 eth0 bw
 command[check_bandwidth]=/usr/lib/nagios/plugins/check_eth -i {{ansible_default_ipv4.interface}} -w 200M Bps -c 200M Bps ### TODO: check ist falschherum. Meldet bei Ueberschreiten aber leider nicht bei unterschreiten.
  
 # Debian Server

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -4,7 +4,7 @@
 connection_timeout=600
 command_timeout=600
 
-allowed_hosts=127.0.0.1,{{ ansible_eth0.ipv4.address }},{{ hostvars[groups['monitoring'][0]]['ansible_ssh_host'] }}
+allowed_hosts=127.0.0.1,{{ ansible_default_ipv4.address }},{{ hostvars[groups['monitoring'][0]]['ansible_ssh_host'] }}
 
 # Speedtest
 command[check_speedtest-cli-2]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -w 2 -c 1 -W 0.2 -C 0.1 -p -s 4193
@@ -13,8 +13,8 @@ command[check_speedtest-cli-50]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -
 command[check_speedtest-cli-100]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -w 100 -c 50 -W 10 -C 5 -p -s 4193
 
 # Bandwith
-#command[check_bandwidth]=/usr/lib/nagios/plugins/check_bandwidth rx 60 eth0 bw
-command[check_bandwidth]=/usr/lib/nagios/plugins/check_eth -i eth0 -w 200M Bps -c 200M Bps ### TODO: check ist falschherum. Meldet bei Ueberschreiten aber leider nicht bei unterschreiten.
+#command[check_bandwidth]=/usr/lib/nagios/plugins/check_bandwidth rx 60 {{ansible_default_ipv4.interface}} bw
+command[check_bandwidth]=/usr/lib/nagios/plugins/check_eth -i {{ansible_default_ipv4.interface}} -w 200M Bps -c 200M Bps ### TODO: check ist falschherum. Meldet bei Ueberschreiten aber leider nicht bei unterschreiten.
  
 # Debian Server
 command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
@@ -34,7 +34,7 @@ command[check_collectd]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C colle
 command[check_pyrespondd]=/usr/lib/nagios/plugins/check_systemd_service py-respondd
 command[check_tunneldigger]=/usr/lib/nagios/plugins/check_tunneldigger
 command[check_dhcp-server]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C kea-dhcp4
-command[check_vnstat]=/usr/lib/nagios/plugins/check_vnstat.sh -i eth0
+command[check_vnstat]=/usr/lib/nagios/plugins/check_vnstat.sh -i {{ansible_default_ipv4.interface}} 
 command[check-dhcp-client]=/usr/lib/nagios/plugins/check_dhcp -t 5
 command[check-dns4-client]=/usr/lib/nagios/plugins/check_dns -H ipv4.google.com -w 0.5 -c 1
 command[check-dns6-client]=/usr/lib/nagios/plugins/check_dns -H ipv6.google.com -w 0.5 -c 1


### PR DESCRIPTION
Die erste Netzwerkschnittstelle heißt nicht mehr eth0 sondern {{ansible_default_ipv4.interface}}