### PR TITLE
batman_install: Repariere Fehlermeldung bei "ansible --check"

### DIFF
--- a/batman_install/tasks/main.yml
+++ b/batman_install/tasks/main.yml
@@ -4,6 +4,7 @@
   register: installed_batman_version
   when: batman.version is defined and batman.version
   changed_when: False
+  check_mode: no
 
 # batman.version != installierte Version: evtl vorhandenes DKMS-batman-adv deinstallieren
 - include: remove-src.yml
@@ -17,6 +18,7 @@
   when: batman.version is defined and batman.version != "kernel" and
         (installed_batman_version.stdout is defined and installed_batman_version.stdout != batman.version)
   changed_when: False
+  check_mode: no
 
 # batman-adv-Version im Kernel passt -> nur batctl installieren
 - include: install-deb.yml

--- a/batman_install/tasks/remove-src.yml
+++ b/batman_install/tasks/remove-src.yml
@@ -6,6 +6,7 @@
     path: /usr/sbin/dkms
   register: stat_dkms
   changed_when: False
+  check_mode: no
 
 # Evtl. vorhandenes batman-adv-DKMS-Modul deinstallieren
 - name: Prüfe ob batman-adv als DKMS-Modul installiert wurde
@@ -13,6 +14,7 @@
   register: dkms_version_batman
   when: stat_dkms.stat.exists
   changed_when: False
+  check_mode: no
 
 - name: DKMS-Modul batman-adv entfernen
   shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} -k {{ ansible_kernel }}"


### PR DESCRIPTION
Installierte und benutzte batman-adv-Versionen auch im Check-Modus von Ansible ermitteln.
