### PR TITLE
motd: Kleinere Fixes

### DIFF
--- a/motd/tasks/main.yml
+++ b/motd/tasks/main.yml
@@ -14,6 +14,7 @@
   register: figlethost
   check_mode: no
   when: figlet_stat.stat.exists
+  changed_when: False
 
 - name: Create /etc/update-motd.d/ directory if not existent
   file:

--- a/motd/tasks/main.yml
+++ b/motd/tasks/main.yml
@@ -8,9 +8,9 @@
   stat: 
     path: /usr/bin/figlet
   register: figlet_stat
-  
+
 - name: figlet name
-  command: /usr/bin/figlet -D -c -w 50 {{freifunk.kurzname}}
+  command: /usr/bin/figlet -c -w 50 {{ freifunk.kurzname }}
   register: figlethost
   check_mode: no
   when: figlet_stat.stat.exists

--- a/motd/tasks/main.yml
+++ b/motd/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: install figlet
-  apt: 
-    pkg: figlet
+- name: install figlet and lsb-release
+  apt:
+    pkg: [ 'figlet', 'lsb-release' ]
     state: present
 
 - name: check figlet

--- a/motd/templates/99-custom.j2
+++ b/motd/templates/99-custom.j2
@@ -15,7 +15,7 @@ echo " IP address  : $(hostname -I | cut -d' ' -f1){% if ansible_default_ipv6.ad
 echo " System type : $(uname -s) $(uname -m)"
 echo " Kernel      : $(uname -r)"
 echo " "
-echo " Owner       : {{ server_besitzer }}"
+echo " Besitzer    : {{ server_besitzer }}"
 
 cat << 'EOF'
 

--- a/motd/templates/99-custom.j2
+++ b/motd/templates/99-custom.j2
@@ -15,7 +15,7 @@ echo " IP address  : $(hostname -I | cut -d' ' -f1){% if ansible_default_ipv6.ad
 echo " System type : $(uname -s) $(uname -m)"
 echo " Kernel      : $(uname -r)"
 echo " "
-echo " Besitzer    : {{ server_besitzer }}"
+echo " Owner       : {{ server_besitzer }}"
 
 cat << 'EOF'
 


### PR DESCRIPTION
- motd benötigt zur Anzeige der Betriebssystemversion das Paket "lsb-release".
- Bei jedem Ansibledurchlauf wurde der Task "figlet-name" als "changed" berichtet obwohl dieser Task nie etwas auf dem Host ändert (das passiert ein paar Tasks später)
- Die Message war komplett auf Englisch, bis auf "Besitzer". Habe das durch "Owner" ersetzt.