### PR TITLE
ntp: Repariere Abschalten von systemd-timesyncd

### DIFF
--- a/ntp/tasks/main.yml
+++ b/ntp/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
 
-- name: ensure systemd NTP client is disabled
-  shell: "timedatectl | grep 'NTP enabled: no' || timedatectl set-ntp 0"
-  register: ntp_shell_result
-  changed_when: "ntp_shell_result.stdout == '' and ntp_shell_result.rc == 0"
-  failed_when: "ntp_shell_result.rc != 0"
+- name: Disable systemd-timesyncd
+  systemd:
+    name: systemd-timesyncd
+    state: stopped
+    masked: yes
 
-- name: Ensure ntp is installed
+- name: Install ntp
   apt: name=ntp
 
 - name: Install ntp.conf


### PR DESCRIPTION
Der Shell-Code, der prüft ob der NTP-Client von systemd abgeschalten ist, funktioniert unter Debian 10 nicht vernünftig. Dadurch wurde der NTP-Client bei jedem Ansible-Durchlauf erneut abgeschaltet ("Status: Changed").

Hab's durch Ansibles systemd-Modul ersetzt und deaktiviere den systemd-timesyncd-Service statt nur seine Funktion lahmzulegen.