### PR TITLE
icinga und nrpe: diverse Kleinigkeiten

### DIFF
--- a/icinga/templates/srv-satellites.conf
+++ b/icinga/templates/srv-satellites.conf
@@ -128,7 +128,7 @@ object Service "Speedtest" {
 {% if hostvars[item]['is_ff_tester'] is defined %}
  {% for domaene in domaenen|dictsort %}
 
-object Service "ffmsd{{domaene[0]}} FreifunkTester Ping IPv4" {
+object Service "{{freifunk.kurzname}}d{{domaene[0]}} FreifunkTester Ping IPv4" {
   import "generic-service"
   host_name = "{{ item }}"
   max_check_attempts = 1
@@ -141,7 +141,7 @@ object Service "ffmsd{{domaene[0]}} FreifunkTester Ping IPv4" {
   vars.notification.hipchat = "1"
 }
 
-object Service "ffmsd{{domaene[0]}} FreifunkTester Ping IPv6" {
+object Service "{{freifunk.kurzname}}d{{domaene[0]}} FreifunkTester Ping IPv6" {
   import "generic-service"
   host_name = "{{ item }}"
   max_check_attempts = 1
@@ -151,7 +151,7 @@ object Service "ffmsd{{domaene[0]}} FreifunkTester Ping IPv6" {
   vars.notification.hipchat = "1"
 }
 
-object Service "ffmsd{{domaene[0]}} FreifunkTester IPv4_Gateway" {
+object Service "{{freifunk.kurzname}}d{{domaene[0]}} FreifunkTester IPv4_Gateway" {
   import "generic-service"
   host_name = "{{ item }}"
   max_check_attempts = 1
@@ -161,7 +161,7 @@ object Service "ffmsd{{domaene[0]}} FreifunkTester IPv4_Gateway" {
   vars.notification.hipchat = "1"
 }
 
-object Service "ffmsd{{domaene[0]}} FreifunkTester IPv6_Gateway" {
+object Service "{{freifunk.kurzname}}d{{domaene[0]}} FreifunkTester IPv6_Gateway" {
   import "generic-service"
   host_name = "{{ item }}"
   max_check_attempts = 1

--- a/nrpe/files/check_active-leases
+++ b/nrpe/files/check_active-leases
@@ -1,4 +1,4 @@
-q#!/usr/bin/python
+#!/usr/bin/python
 import datetime, bisect
 
 def parse_timestamp(raw_str):

--- a/nrpe/handlers/main.yml
+++ b/nrpe/handlers/main.yml
@@ -1,14 +1,3 @@
 ---
-- name: Start nagios-nrpe-server
-  service: name=nagios-nrpe-server state=started
-
-- name: Stop nagios-nrpe-server
-  service: name=nagios-nrpe-server state=stoped
-
 - name: Reload nagios-nrpe-server
   service: name=nagios-nrpe-server state=reloaded
-
-- name: Restart nagios-nrpe-server
-  service: name=nagios-nrpe-server state=restarted
-
-

--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -6,6 +6,7 @@
 
 - name: Configure NRPE-Server
   template: "src=nrpe_local.cfg.j2 dest='/etc/nagios/nrpe_local.cfg' owner=root group=root"
+  notify: Reload nagios-nrpe-server
 
 - name: Install Nagios Plugins
   package:
@@ -26,6 +27,11 @@
   package:
     name: vnstati
     state: latest
+
+- name: Install sudo
+  apt:
+    name: sudo
+    state: present
 
 - name: Install RAM check
   copy: "src=check_ram dest='/usr/lib/nagios/plugins/check_ram' owner=root group=root mode=a+x"
@@ -71,24 +77,11 @@
 - name: Install check_bird6_sessions
   copy: "src=check_bird6_sessions dest='/usr/lib/nagios/plugins/check_bird6_sessions' owner=root group=root mode=a+x"
 
-- name: Sudo Recht check_bird_sessions
-  lineinfile: dest=/etc/sudoers line='nagios ALL=NOPASSWD{{ ":" }} /usr/lib/nagios/plugins/check_bird_sessions' state=present
+- name: Install sudo permissions
+  template: "src=sudoers.j2 dest='/etc/sudoers.d/nrpe' owner=root group=root mode=440"
 
-- name: Sudo Recht check_bird6_sessions
-  lineinfile: dest=/etc/sudoers line='nagios ALL=NOPASSWD{{ ":" }} /usr/lib/nagios/plugins/check_bird6_sessions' state=present
-
-- name: Sudo Recht check_FFTester
-  lineinfile: dest=/etc/sudoers line='nagios ALL=NOPASSWD{{ ":" }} /root/gits/tools/Freifunk-Tester/icinga_reporter.sh' state=present
-  when: is_ff_tester is defined
-
-- name: stop NRPE-Server
-  service:
-    name: nagios-nrpe-server
-    state: stopped
-
-- name: start NRPE-Server
-  service:
+- name: enable NRPE-Server
+  systemd:
     name: nagios-nrpe-server
     state: started
-
-
+    enabled: yes

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -1,10 +1,9 @@
-######################################
-# Do any local nrpe configuration here
-######################################
+# {{ ansible_managed }}
+
 connection_timeout=600
 command_timeout=600
 
-allowed_hosts=127.0.0.1,{{ ansible_default_ipv4.address }},{{ hostvars[groups['monitoring'][0]]['ansible_ssh_host'] }}
+allowed_hosts=127.0.0.1,{{ ansible_default_ipv4.address }},{{ groups['monitoring']|default([]) | map('extract',hostvars, ['ansible_ssh_host']) | join(',') }}
 
 # Speedtest
 command[check_speedtest-cli-2]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -w 2 -c 1 -W 0.2 -C 0.1 -p -s 4193
@@ -63,7 +62,7 @@ command[check_batip_{{domaene[0]}}]=/usr/lib/nagios/plugins/check_batip -D {{dom
 #{% if 'monitoring-satellites' in group_names and is_ff_tester is defined %}
 ## Freifunk-Tester
 # {% for domaene in domaenen|dictsort %}
-#command[check_FFTesterV4_{{domaene[0]}}]=sudo /root/gits/tools/Freifunk-Tester/icinga_reporter.sh ffmsd{{domaene[0]}} IPv4-ping-test-to-google.de random
-#command[check_FFTesterV6_{{domaene[0]}}]=sudo /root/gits/tools/Freifunk-Tester/icinga_reporter.sh ffmsd{{domaene[0]}} IPv6-ping-test-to-google.de random
+#command[check_FFTesterV4_{{domaene[0]}}]=sudo /root/gits/tools/Freifunk-Tester/icinga_reporter.sh {{freifunk.kurzname}}d{{domaene[0]}} IPv4-ping-test-to-google.de random
+#command[check_FFTesterV6_{{domaene[0]}}]=sudo /root/gits/tools/Freifunk-Tester/icinga_reporter.sh {{freifunk.kurzname}}d{{domaene[0]}} IPv6-ping-test-to-google.de random
 # {% endfor %}
 #{% endif %}

--- a/nrpe/templates/sudoers.j2
+++ b/nrpe/templates/sudoers.j2
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+nagios ALL=NOPASSWD: /usr/lib/nagios/plugins/check_bird_sessions
+nagios ALL=NOPASSWD: /usr/lib/nagios/plugins/check_bird6_sessions
+# nagios ALL=NOPASSWD: /root/gits/tools/Freifunk-Tester/icinga_reporter.sh


### PR DESCRIPTION
Icinga:
- icinga/templates/srv-satellites.conf: "ffms" durch "{{ freifunk.kurzname }}" ersetzen

nrpe:
- nrpe/templates/nrpe_local.cfg: "ffms" durch "{{ freifunk.kurzname }}" ersetzen
- Mehrere Monitoring-Server erlauben
- sudo-Paket installieren
- sudo-Konfiguration nach /etc/sudoers.d/nrpe auslagern
- Typo in nrpe/files/check_active-leases beheben
- Ansible-Handler für reload benutzen, nicht benutzte Handler entfernen