### PR TITLE
ntp: (Neu)start

### DIFF
--- a/ntp/handlers/main.yml
+++ b/ntp/handlers/main.yml
@@ -1,4 +1,10 @@
 ---
 
 - name: Restart ntpd
-  service: name=ntp state=restarted
+  systemd:
+    name: ntp
+    state: restarted
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes

--- a/ntp/tasks/main.yml
+++ b/ntp/tasks/main.yml
@@ -7,8 +7,25 @@
     masked: yes
 
 - name: Install ntp
-  apt: name=ntp
+  apt:
+    name: ntp
 
 - name: Install ntp.conf
-  template: src=ntp.conf.j2 dest=/etc/ntp.conf
+  template:
+    src: ntp.conf.j2
+    dest: /etc/ntp.conf
   notify: Restart ntpd
+
+- name: create folder for ntp service override file
+  file:
+    path: /etc/systemd/system/ntp.service.d
+    state: directory
+    mode: 0755
+
+- name: override ntp service
+  template:
+    src: ntp.service.override.j2
+    dest: /etc/systemd/system/ntp.service.d/ansible-managed.conf
+  notify:
+    - reread systemd configs
+    - Restart ntpd

--- a/ntp/templates/ntp.service.override.j2
+++ b/ntp/templates/ntp.service.override.j2
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+[Unit]
+After=network-online.target
+
+[Service]
+Restart=on-failure


### PR DESCRIPTION
- NTP startet gelegentlich schneller als die Netzwerkinterfaces IP-Adressen haben, darum auf network-online.target warten
- NTP bei Abbruch automatisch neu starten