### PR TITLE
common: journald-Logging beschränken

### DIFF
--- a/common/handlers/main.yml
+++ b/common/handlers/main.yml
@@ -3,3 +3,8 @@
 
 - name: reload resolv config
   shell: resolvconf -u
+
+- name: restart journald
+  service:
+    name: systemd-journald
+    state: restarted

--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -90,6 +90,19 @@
     dest: /etc/logrotate.d/wtmp
   when: logrotate is defined
 
+- name: Prüfe ob journald benutzt wird
+  stat:
+    path: /etc/systemd/journald.conf
+  register: journald_conf
+
+- name: journald-Logging zeitlich beschränken
+  lineinfile:
+    dest: /etc/systemd/journald.conf
+    regexp: "^[#]?MaxRetentionSec"
+    line: "MaxRetentionSec={{ logrotate.count }}week"
+  when: journald_conf.stat.exists == True
+  notify: restart journald
+
 - name: Setze Timeout für das stopen von Interfaces
   lineinfile:
     dest: /lib/systemd/system/networking.service.d/network-pre.conf


### PR DESCRIPTION
Logging mit journald auf den gleichen Zeitraum beschränken wie bei logrotate konfiguriert (logrotate.count Wochen)