### PR TITLE
bird: kleine Ansible-Änderungen

### DIFF
--- a/bird/handlers/main.yml
+++ b/bird/handlers/main.yml
@@ -1,7 +1,15 @@
 ---
-- name: configure bird
-  shell: birdc configure || systemctl restart bird
+- name: reload bird
+  systemd:
+    name: bird
+    state: reloaded
 
-- name: configure bird6
-  shell: birdc6 configure || systemctl restart bird6
+- name: reload bird6
+  systemd:
+    name: bird6
+    state: reloaded
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes
 

--- a/bird/tasks/main.yml
+++ b/bird/tasks/main.yml
@@ -11,7 +11,7 @@
     state: present
   when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
 
-- name: install bird and other required packets (Debian 9 only)
+- name: install bird and other required packets (Debian 8 only)
   apt:
     pkg: ['bird', 'bird6', 'ipcalc']
     update_cache: yes
@@ -36,51 +36,45 @@
   when: domaenenliste is defined
 
 - name: configure bird.conf
-  template: 
+  template:
     src: bird.conf.j2
     dest: /etc/bird/bird.conf
+    owner: bird
+    group: bird
   notify:
-    - configure bird
+    - reload bird
 
 - name: configure bird6.conf
   template:
     src: bird6.conf.j2
     dest: /etc/bird/bird6.conf
+    owner: bird
+    group: bird
   notify:
-    - configure bird6
+    - reload bird6
 
 - name: create folder for bird.service file
-  file: path=/etc/systemd/system/bird.service.d state=directory mode=0755
+  file:
+    path: /etc/systemd/system/bird.service.d
+    state: directory
+    mode: 0755
 
 - name: bird.service kopieren
-  copy: 
+  copy:
     src: bird.service
     dest: /etc/systemd/system/bird.service.d/override.conf
   notify:
-    - configure bird
+    - reread systemd configs
 
 - name: create folder for bird6.service file
-  file: path=/etc/systemd/system/bird6.service.d state=directory mode=0755
+  file:
+    path: /etc/systemd/system/bird6.service.d
+    state: directory
+    mode: 0755
 
 - name: bird6.service kopieren
-  copy: 
+  copy:
     src: bird6.service
     dest: /etc/systemd/system/bird6.service.d/override.conf
   notify:
-    - configure bird6
-
-- name: reread systemd configs
-  systemd:
-    daemon_reload: yes
-
-- name: activate and start bird
-  service:
-    name: bird
-    state: started 
-    enabled: yes
-
-- name: activate and start bird6
-  service: 
-    name: bird6
-    state: started
-    enabled: yes
+    - reread systemd configs


### PR DESCRIPTION
- Dienste nicht in tasks sondern in handlers neu starten
- "Debian 9"-Typo ausbessern
- Konfigurationsdateien explizit User und Gruppe "bird" zuweisen