### PR TITLE
Fix: Dienste bei Änderung der systemd-Servicedefinition nicht neu starten

### DIFF
--- a/gateways_bind/handlers/main.yml
+++ b/gateways_bind/handlers/main.yml
@@ -1,3 +1,7 @@
 ---
 - name: restart bind9
   service: name=bind9 state=restarted
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes

--- a/gateways_bind/tasks/main.yml
+++ b/gateways_bind/tasks/main.yml
@@ -63,11 +63,7 @@
 - name: copy bind9.service
   copy: src=bind9.service dest=/etc/systemd/system/bind9.service.d/override.conf
   notify:
-    - restart bind9
-
-- name: reread systemd configs
-  systemd:
-    daemon_reload: yes
+    - reread systemd configs
 
 - name: Deploy logrotate template file
   template:

--- a/gateways_dhcp/tasks/main.yml
+++ b/gateways_dhcp/tasks/main.yml
@@ -24,6 +24,8 @@
 
 - name: tmpfs systemd service for dhcpd
   template: src=dhcpd-tmpfs.service.j2 dest=/etc/systemd/system/dhcpd-tmpfs.service
+  notify:
+    - reread systemd configs
 
 - name: enable dhcpd-tmpfs service
   service: name=dhcpd-tmpfs enabled=yes state=started
@@ -53,4 +55,3 @@
     dest: /etc/systemd/system/isc-dhcp-server.service.d/ansible-managed.conf
   notify:
     - reread systemd configs
-    - restart isc-dhcp-server

--- a/gateways_fastd/handlers/main.yml
+++ b/gateways_fastd/handlers/main.yml
@@ -5,3 +5,8 @@
     state: restarted
   when: item.value.fastd is defined and item.value.fastd
   with_dict: "{{ domaenenliste }}"
+
+- name: reread systemd configs
+  systemd:
+    daemon_reload: yes
+

--- a/gateways_fastd/tasks/main.yml
+++ b/gateways_fastd/tasks/main.yml
@@ -150,7 +150,6 @@
   when: fastd_on_this_gw is defined and fastd_on_this_gw
   notify:
     - reread systemd configs
-    - restart fastd per domain
 
 - name: create folder for haveged service override file
   file:
@@ -167,7 +166,6 @@
   when: fastd_on_this_gw is defined and fastd_on_this_gw
   notify:
     - reread systemd configs
-    - restart haveged
 
 - name: enable fastd for each domain
   systemd:

--- a/ntp/tasks/main.yml
+++ b/ntp/tasks/main.yml
@@ -28,4 +28,3 @@
     dest: /etc/systemd/system/ntp.service.d/ansible-managed.conf
   notify:
     - reread systemd configs
-    - Restart ntpd


### PR DESCRIPTION
Wie bei https://github.com/FreiFunkMuenster/Ansible-Freifunk-Gateway/pull/96#discussion_r340079452 versprochen bin ich die Rollen im Hinblick auf überflüssige Neustarts bei Änderung der Service-Definition durchgegangen.
