### PR TITLE
Match 2017.4 as well as 2013.4.0 ...

### DIFF
--- a/batman_install/tasks/install-legacy-src.yml
+++ b/batman_install/tasks/install-legacy-src.yml
@@ -1,0 +1,66 @@
+- name: Abhängigkeiten installieren
+  apt:
+    pkg: ['dkms', 'build-essential', 'linux-headers-{{ansible_kernel}}', 'pkg-config', 'libnl-3-dev', 'libnl-genl-3-dev', 'git']
+    state: present
+
+- name: create directory for batman-adv
+  file:
+    name: /opt/batman-adv
+    state: directory
+
+- name: Download Gluon maintained batman-adv-legacy 
+  shell: "cd /usr/src && /bin/rm -rf batman-adv-2013.4.0 && git clone https://github.com/freifunk-gluon/batman-adv-legacy.git batman-adv-2013.4.0" 
+  register: getbatman
+
+# Gluon's batman-adv-legacy already has a working dkms.conf
+#- name: configure dkms
+#  template: 
+#    src: dkms.conf
+#    dest: /usr/src/batman-adv-{{batman.version}}/dkms.conf
+#
+- stat: 
+    path: /lib/modules/{{ansible_kernel}}/updates/dkms/batman-adv.ko
+  register: batman_adv_file
+
+- name: Batman bauen
+  shell: "(dkms status -m batman-adv -v {{batman.version}} | grep batman-adv || dkms add -m batman-adv -v {{batman.version}}) && dkms build -m batman-adv -v {{batman.version}} && dkms install -m batman-adv -v {{batman.version}} --force"
+  when:
+    - batman_adv_file.stat.exists == False or getbatman.changed
+
+# batctl
+- name: create directory for batctl
+  file:
+    name: /opt/batctl
+    state: directory
+
+- name: get batctl
+  get_url:
+    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{batman.version}}/batctl-{{batman.version}}.tar.gz"
+    dest: /opt/batctl/batctl-{{batman.version}}.tar.gz
+  register: getbatctl
+
+- name: batctl-Quellen und entpacken
+  unarchive:
+    src: /opt/batctl/batctl-{{batman.version}}.tar.gz
+    dest: /usr/src
+    remote_src: True
+  when:
+    - getbatctl.changed
+
+- stat: path=/usr/local/sbin/batctl
+  register: batctl
+
+- name: batctl Version prüfen
+  shell: '{{batctl.stat.path}} -v | grep -oE "batctl [0-9]+\.[0-9]+(\.[0-9]+)?"'
+  when: 
+    - batctl.stat.exists == True
+  changed_when: False
+  register: batctl_version
+  check_mode: no
+
+- name: batctl bauen
+  shell: "make && make install"
+  args:
+    chdir: /usr/src/batctl-{{batman.version}}
+  when:
+    - batctl.stat.exists == False or batctl_version.stdout_lines[0] != "batctl {{batman.version}}"

--- a/batman_install/tasks/main.yml
+++ b/batman_install/tasks/main.yml
@@ -32,5 +32,10 @@
 
 # batman-adv und batctl aus Quellen bauen
 - include: install-src.yml
-  when: (batman.version is defined and batman.version != "kernel") and
+  when: (batman.version is defined and (batman.version != "kernel" and batman.version != "2013.4.0")) and
+        (installed_batman_version.stdout is defined and installed_batman_version.stdout != batman.version)
+
+# Legacy (v14) batman-adv und batctl aus Gluon-Quellen bauen
+- include: install-legacy-src.yml
+  when: (batman.version is defined and batman.version == "2013.4.0") and
         (installed_batman_version.stdout is defined and installed_batman_version.stdout != batman.version)

--- a/batman_install/tasks/remove-src.yml
+++ b/batman_install/tasks/remove-src.yml
@@ -10,7 +10,7 @@
 
 # Evtl. vorhandenes batman-adv-DKMS-Modul deinstallieren
 - name: Prüfe ob batman-adv als DKMS-Modul installiert wurde
-  shell: dkms status batman-adv -k {{ ansible_kernel }} | grep -Eo '[[:digit:]]{4}\.[[:digit:]]' || true
+  shell: dkms status batman-adv -k {{ ansible_kernel }} | grep -Eo '[[:digit:]]{4}\.[[:digit:]](\.[[:digit:]])?' || true
   register: dkms_version_batman
   when: stat_dkms.stat.exists
   changed_when: False

--- a/batman_install/tasks/remove-src.yml
+++ b/batman_install/tasks/remove-src.yml
@@ -18,7 +18,11 @@
 
 - name: DKMS-Modul batman-adv entfernen
   shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} -k {{ ansible_kernel }}"
-  when: stat_dkms.stat.exists and dkms_version_batman.stdout
+  when: (batman.version is not defined or batman.version != "2013.4.0") and stat_dkms.stat.exists and dkms_version_batman.stdout
+
+- name: Legacy DKMS-Modul batman-adv entfernen
+  shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} --all"
+  when: (batman.version is defined and batman.version == "2013.4.0") and stat_dkms.stat.exists and dkms_version_batman.stdout
 
 
 # batctl


### PR DESCRIPTION
As discussed, this fixes "Error! There are no instances of module: batman-adv\n2013.4 located in the DKMS tree."