### PR TITLE
gateways_batman: Feste MAC-Adressen für die Batman-Interfaces vergeben

### DIFF
--- a/gateways_batman/templates/batman.j2
+++ b/gateways_batman/templates/batman.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # Batman Interface
-# - Erstellt das virtuelle Interface fuer das Batman-Modul und bindet dieses, falls L2TP benutzt wird, an die Netzwerkbruecke
+# - Erstellt das virtuelle Interface fuer das Batman-Modul und bindet dieses, falls L2TP oder Fastd benutzt wird, an die Netzwerkbruecke
 # - Die unten angelegte Routing-Tabelle wird spaeter fuer das Routing innerhalb von Freifunk (Router/VPN) verwendet
 
 {% for item in domaenenliste|dictsort %}
@@ -9,6 +9,11 @@ auto bat{{item[0]}}
 iface bat{{item[0]}} inet static
         address {{domaenen[item[0]].ffv4_network | ipaddr(item[1].server_id) | ipaddr('address') }}
         netmask {{domaenen[item[0]].ffv4_network | ipaddr('netmask')}}
+{% if item[0] | length > 2 %}
+        hwaddress f2:be:ef:{{item[0][0:2]}}:{{item[0][2:]}}:{{item[1].server_id}}
+{% else %}
+        hwaddress f2:be:ef:00:{{item[0]}}:{{item[1].server_id}}
+{% endif %}
         pre-up modprobe batman-adv
         pre-up ip link add bat{{item[0]}} type batadv
         post-up ip link set dev bat{{item[0]}} up


### PR DESCRIPTION
Bislang ändern sich die MAC-Adressen der Batman-Interfaces bei jedem Reboot des Gateways.

NeoRaider sagt: "For batadv, I consider any setup that doesn't fix all MAC addresses broken" (siehe https://github.com/ffnord/mesh-announce/pull/48#issuecomment-548270279)

Löst auch das Problem, dass bei Verwendung von mesh-announce jeder Gateway-Reboot zu einem neuen und einem toten Gateway auf der Freifunk-Karte führt.

Der MAC-Adressbereich f2... ist nicht vergeben.