### PR TITLE
nrpe: check_batip/check_batip6

### DIFF
--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -60,10 +60,10 @@
   copy: "src=check_active-leases dest='/usr/lib/nagios/plugins/check_active-leases' owner=root group=root mode=a+x"
 
 - name: Install check_batip
-  copy: "src=check_batip dest='/usr/lib/nagios/plugins/check_batip' owner=root group=root mode=a+x"
+  template: "src=check_batip.j2 dest='/usr/lib/nagios/plugins/check_batip' owner=root group=root mode=a+x"
 
 - name: Install check_batip6
-  copy: "src=check_batip6 dest='/usr/lib/nagios/plugins/check_batip6' owner=root group=root mode=a+x"
+  template: "src=check_batip6.j2 dest='/usr/lib/nagios/plugins/check_batip6' owner=root group=root mode=a+x"
 
 - name: Install check_iproute
   copy: "src=check_iproute dest='/usr/lib/nagios/plugins/check_iproute' owner=root group=root mode=a+x"

--- a/nrpe/templates/check_batip.j2
+++ b/nrpe/templates/check_batip.j2
@@ -7,11 +7,14 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
 #########################################################################
-# Pro Domäne die a.b.c.2, a.b.c.3, a.b.c.11 und a.b.c.12 pingen, falls zwei nicht pingbar ? Wahrscheinlich hängt das Batman 
-# iPV6
+# Pro DomÃ¤ne max. sechs Server pingen, falls mehr als die HÃ¤lfte nicht pingbar ? Wahrscheinlich hÃ¤ngt das Batman 
 #########################################################################
 
-CHECKIP="2 3 b c"
+MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'server_id') | join(" ") }}"
+GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'server_id') | join(" ") }}"
+CHECKIP="$MAPSERVER $GATEWAYS"
+
+COUNTREQUIRED=$(($(echo $CHECKIP | wc -w)/2))
 
 PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 export PATH
@@ -19,7 +22,7 @@ PROGNAME=`basename $0`
 PROGPATH=`echo $0 | sed -e 's,[\\/][^\\/][^\\/]*$,,'`
 REVISION="2.2"
 
-# . $PROGPATH/utils.sh
+. $PROGPATH/utils.sh
 
 print_usage() {
     echo "Usage: $PROGNAME -D {Domain}"
@@ -29,7 +32,7 @@ print_usage() {
 print_help() {
     print_usage
     echo ""
-    echo "Batman pro Domain per IP überwachen"
+    echo "Batman pro Domain per IP Ã¼berwachen"
     echo ""
     support
 }
@@ -66,7 +69,7 @@ while test -n "$1"; do
     shift
 done
 
-IPBASE=$(ip -f inet6 -o addr show bat$DOMAIN | sed -n 's/.*inet6 \(.*\)[0-9]\/64 scope global.*/\1/p')
+IPBASE=$(ip -f inet -o addr show bat$DOMAIN | sed -e 's/.*inet \([0-9]*\.[0-9]*\.[0-9]*\.\).*/\1/g')
 if [ "$IPBASE" == "" ] ; then
   echo "UNKNOWN: interface bat$DOMAIN not found"
   exit $STATE_UNKNOWN
@@ -76,16 +79,16 @@ fi
 COUNTOK=0
 
 for a in $CHECKIP ; do
-  # echo $IPBASE$a
-  ping6  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
+  #echo $IPBASE$a
+  ping  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
 done
 
 #echo es antworten $COUNTOK IPs 
 
-if [ $COUNTOK -lt 3 ]; then
-  echo "CRITICAL: Es antworten nur $COUNTOK der V6Domain-IPs $CHECKIP"
+if [ $COUNTOK -le $COUNTREQUIRED ]; then
+  echo "CRITICAL: Es antworten nur $COUNTOK der Domain-IPs $CHECKIP"
   exit $STATE_CRITICAL
 else
-  echo "OK: es antworten $COUNTOK der V6Domain-IPs $CHECKIP"
+  echo "OK: es antworten $COUNTOK der Domain-IPs $CHECKIP"
   exit $STATE_OK
 fi

--- a/nrpe/templates/check_batip6.j2
+++ b/nrpe/templates/check_batip6.j2
@@ -7,10 +7,16 @@ STATE_CRITICAL=2
 STATE_UNKNOWN=3
 
 #########################################################################
-# Pro Domäne die a.b.c.2, a.b.c.3, a.b.c.11 und a.b.c.12 pingen, falls zwei nicht pingbar ? Wahrscheinlich hängt das Batman 
+# Pro DomÃ¤ne max. sechs Server pingen, falls mehr als die HÃ¤lfte nicht pingbar ? Wahrscheinlich hÃ¤ngt das Batman 
+#########################################################################
+# iPV6
 #########################################################################
 
-CHECKIP="2 3 11 12"
+MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'server_id') | join(" ") }}"
+GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'server_id') | join(" ") }}"
+CHECKIP="$MAPSERVER $GATEWAYS"
+
+COUNTREQUIRED=$(($(echo $CHECKIP | wc -w)/2))
 
 PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 export PATH
@@ -18,7 +24,7 @@ PROGNAME=`basename $0`
 PROGPATH=`echo $0 | sed -e 's,[\\/][^\\/][^\\/]*$,,'`
 REVISION="2.2"
 
-. $PROGPATH/utils.sh
+# . $PROGPATH/utils.sh
 
 print_usage() {
     echo "Usage: $PROGNAME -D {Domain}"
@@ -28,7 +34,7 @@ print_usage() {
 print_help() {
     print_usage
     echo ""
-    echo "Batman pro Domain per IP überwachen"
+    echo "Batman pro Domain per IP Ã¼berwachen"
     echo ""
     support
 }
@@ -65,7 +71,7 @@ while test -n "$1"; do
     shift
 done
 
-IPBASE=$(ip -f inet -o addr show bat$DOMAIN | sed -e 's/.*inet \([0-9]*\.[0-9]*\.[0-9]*\.\).*/\1/g')
+IPBASE=$(ip -f inet6 -o addr show bat$DOMAIN | sed -n 's/.*inet6 \(.*\)[0-9]\/64 scope global.*/\1/p')
 if [ "$IPBASE" == "" ] ; then
   echo "UNKNOWN: interface bat$DOMAIN not found"
   exit $STATE_UNKNOWN
@@ -75,16 +81,16 @@ fi
 COUNTOK=0
 
 for a in $CHECKIP ; do
-  #echo $IPBASE$a
-  ping  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
+  # echo $IPBASE$a
+  ping6  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
 done
 
 #echo es antworten $COUNTOK IPs 
 
-if [ $COUNTOK -lt 3 ]; then
-  echo "CRITICAL: Es antworten nur $COUNTOK der Domain-IPs $CHECKIP"
+if [ $COUNTOK -le $COUNTREQUIRED ]; then
+  echo "CRITICAL: Es antworten nur $COUNTOK der V6Domain-IPs $CHECKIP"
   exit $STATE_CRITICAL
 else
-  echo "OK: es antworten $COUNTOK der Domain-IPs $CHECKIP"
+  echo "OK: es antworten $COUNTOK der V6Domain-IPs $CHECKIP"
   exit $STATE_OK
 fi


### PR DESCRIPTION
Die beiden check_batip-Skripte prüfen zur Zeit feste, im Skript hartcodierte IP-Adressen.
Wenn ich es richtig sehe sind das ein paar Gateways von euch und euer Mapserver.

Ich habe die beiden Skripte zu Templates umgebaut:
- Statt fixer IP-Adressen zu verwenden werden die IP-Adressen des Mapservers und die der ersten max. vier Gateways von Ansible als zu prüfende IP-Adressen in die beiden Skripte eingetragen, in Summe also maximal 5 zu prüfende Ziele.
- Den Status "Fehler" gibt's wenn weniger als die Hälfte der IP-Adressen erreichbar sind.