### PR TITLE
gateways_respondd: Möglicher Ersatz für py-respondd

### DIFF
--- a/gateways_respondd/handlers/main.yml
+++ b/gateways_respondd/handlers/main.yml
@@ -1,0 +1,8 @@
+- name: systemctl reload
+  shell: systemctl daemon-reload
+
+- name: restart respondd
+  service:
+    name: respondd.service
+    state: restarted
+    enabled: yes

--- a/gateways_respondd/tasks/main.yml
+++ b/gateways_respondd/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install dependencies
+  apt:
+    pkg: ['python3', 'ethtool', 'lsb-release' ]
+    state: present
+
+- name: Clone mesh-announce repo
+  git:
+    repo: https://github.com/ffnord/mesh-announce.git
+    dest: /opt/mesh-announce
+    clone: yes
+    update: yes
+  notify: restart respondd
+
+- name: create systemd file
+  template:
+    src: respondd.service.j2
+    dest: /etc/systemd/system/respondd.service
+  notify: systemctl reload
+
+- name: enable respondd
+  systemd:
+    name: respondd
+    enabled: yes
+    masked: no
+  notify: systemctl reload

--- a/gateways_respondd/templates/respondd.service.j2
+++ b/gateways_respondd/templates/respondd.service.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Respondd
+After=network.target
+
+[Service]
+ExecStart=/opt/mesh-announce/respondd.py -d /opt/mesh-announce/providers {{ domaenenliste.keys() | map('regex_replace', '^(.*)$', '-i br\\1 -i bat\\1 -b bat\\1') | join(" ") }}
+Restart=on-failure
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[Install]
+WantedBy=multi-user.target

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -31,6 +31,7 @@ command[check_bird6]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C bird6
 command[check_bind]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C named
 command[check_collectd]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C collectd
 command[check_pyrespondd]=/usr/lib/nagios/plugins/check_systemd_service py-respondd
+command[check_respondd]=/usr/lib/nagios/plugins/check_systemd_service respondd
 command[check_tunneldigger]=/usr/lib/nagios/plugins/check_tunneldigger
 command[check_dhcp-server]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C kea-dhcp4
 command[check_vnstat]=/usr/lib/nagios/plugins/check_vnstat.sh -i {{ansible_default_ipv4.interface}} 


### PR DESCRIPTION
Das ist - wie alle Pull Requests - ein Angebot das ihr auch ablehnen könnt.

Die Rolle implementiert mesh-announce (https://github.com/ffnord/mesh-announce)

Hab's so umgebaut dass noch eine einzige Instanz pro Gateway gestartet wird, die dann für alle Domänen zuständig ist. Die von Ansible erzeugte Konfiguration sieht gut aus, ich kann's mangels Domänen aber nicht auf Funktionsfähigkeit testen.
Kompatibel mit yanic.