### PR TITLE
Ubuntu 18.04-Unterstützung verbessern, Debian 8-Unterstützung entfernen

### DIFF
--- a/bird/tasks/main.yml
+++ b/bird/tasks/main.yml
@@ -1,38 +1,21 @@
 ---
 # Role for configure bird and bird6 for our gateway servers.
-- name: Add repo key for bird (Debian 8 only)
-  apt_key:
-    url: https://bird.network.cz/debian/apt.gpg
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-
-- name: add bird repo (Debian 8 only)
-  apt_repository:
-    repo: "deb [trusted=yes] http://bird.network.cz/debian/ {{ ansible_distribution_release }} main"
-    state: present
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-
-- name: install bird and other required packets (Debian 8 only)
-  apt:
-    pkg: ['bird', 'bird6', 'ipcalc']
-    update_cache: yes
-    cache_valid_time: 1800
-    state: present
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-
 - name: install bird and other required packets
   apt:
-    pkg: ['bird', 'ipcalc']
-    update_cache: yes
+    name: ['bird', 'ipcalc']
     cache_valid_time: 1800
-    state: present
-  when: not (ansible_distribution == "Debian" and ansible_distribution_major_version == "8")
 
 - name: calculate more specific routes for DHCP pools
-  shell: ipcalc {{ domaenenliste[item].dhcp_start }} - {{ domaenenliste[item].dhcp_ende}} | grep -v "deaggregate" | sed -e 's/\(^.*$\)/route \1 via "bat{{item}}";/g'
+  shell: |
+    set -o pipefail
+    ipcalc {{ domaenenliste[item].dhcp_start }} - {{ domaenenliste[item].dhcp_ende }} | \
+    grep -v "deaggregate" | sed -e 's/\(^.*$\)/route \1 via "bat{{ item }}";/g'
+  args:
+    executable: bash
   check_mode: no
   changed_when: false
   register: more_specific_routes
-  with_items: "{{domaenenliste | default([])}}"
+  with_items: "{{ domaenenliste | default([]) }}"
   when: domaenenliste is defined
 
 - name: configure bird.conf

--- a/common/handlers/main.yml
+++ b/common/handlers/main.yml
@@ -1,10 +1,12 @@
 - name: reload sshd
-  shell: systemctl reload ssh
+  systemd:
+    name: ssh
+    state: reloaded
 
 - name: reload resolv config
-  shell: resolvconf -u
+  command: resolvconf -u
 
 - name: restart journald
-  service:
+  systemd:
     name: systemd-journald
     state: restarted

--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -27,9 +27,9 @@
 
 - name: install common packages
   apt:
-    pkg: ['vim', 'wget', 'vnstat', 'tmux', 'pastebinit', 'htop', 'jnettop', 'iotop', 'tcpdump', 'screen', 'strace', 'socat', 'dnsutils', 'host', 'apt-transport-https', 'tshark', 'dwdiff', 'molly-guard', 'git', 'iperf3', 'mtr-tiny', 'dhcpdump', 'dhcping', 'irqbalance', 'build-essential', 'ethtool']
+    name: ['vim', 'wget', 'vnstat', 'tmux', 'pastebinit', 'htop', 'jnettop', 'iotop', 'tcpdump', 'screen', 'strace', 'socat', 'dnsutils', 'host', 'ifupdown',
+      'apt-transport-https', 'tshark', 'dwdiff', 'molly-guard', 'git', 'iperf3', 'mtr-tiny', 'dhcpdump', 'dhcping', 'irqbalance', 'build-essential', 'ethtool']
     update_cache: yes
-    state: present
 
 - name: uninstall unneeded packages
   apt:
@@ -50,7 +50,8 @@
     line: "PasswordAuthentication no"
   notify: reload sshd
 
-- locale_gen: name=de_DE.UTF-8 state=present
+- name: Unterstützung für deutsche Sprache aktivieren
+  locale_gen: name=de_DE.UTF-8 state=present
 
 - name: "Get all files in /etc/logrotate.d/"
   raw: find /etc/logrotate.d/ -type f
@@ -60,17 +61,17 @@
 
 - name: "Update logrotate cycle in /etc/logrotate.d/"
   replace:
-    dest: "{{item}}"
+    dest: "{{ item }}"
     regexp: 'daily|weekly|monthly'
-    replace: '{{logrotate.cycle}}'
-  with_items: "{{logrotate_files.stdout_lines}}"
+    replace: '{{ logrotate.cycle }}'
+  with_items: "{{ logrotate_files.stdout_lines }}"
 
 - name: "Update logrotate count in /etc/logrotate.d/"
   replace:
-    dest: "{{item}}"
+    dest: "{{ item }}"
     regexp: 'rotate[ \t]+[0-9]+'
-    replace: 'rotate {{logrotate.count}}'
-  with_items: "{{logrotate_files.stdout_lines}}"
+    replace: 'rotate {{ logrotate.count }}'
+  with_items: "{{ logrotate_files.stdout_lines }}"
 
 - name: Logrotate Rotationszyklus und Anzahl anpassen
   template:
@@ -100,23 +101,8 @@
     dest: /etc/systemd/journald.conf
     regexp: "^[#]?MaxRetentionSec"
     line: "MaxRetentionSec={{ logrotate.count }}week"
-  when: journald_conf.stat.exists == True
+  when: journald_conf.stat.exists
   notify: restart journald
-
-- name: Setze Timeout für das stopen von Interfaces
-  lineinfile:
-    dest: /lib/systemd/system/networking.service.d/network-pre.conf
-    line: "[Service]"
-    state: present
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
-
-- name: Setze Timeout für das stopen von Interfaces
-  lineinfile:
-    dest: /lib/systemd/system/networking.service.d/network-pre.conf
-    regexp: "^TimeoutStopSec="
-    line: "TimeoutStopSec=60"
-    state: present
-  when: ansible_distribution == "Debian" and ansible_distribution_major_version == "8"
 
 - name: vnstat Bandbreiten limit auf 1000 Mbit erhöhen.
   lineinfile:
@@ -124,4 +110,3 @@
     regexp: "^MaxBandwidth"
     line: "MaxBandwidth 1000"
     state: present
-

--- a/gateways_batman/tasks/main.yml
+++ b/gateways_batman/tasks/main.yml
@@ -2,7 +2,6 @@
 - name: bridge-utils-Paket installieren
   apt:
     pkg: ['bridge-utils']
-    state: present
 
 # creating batman interface
 - name: Create interfaces - batman file

--- a/gateways_dhcp/tasks/main.yml
+++ b/gateways_dhcp/tasks/main.yml
@@ -55,3 +55,8 @@
     dest: /etc/systemd/system/isc-dhcp-server.service.d/ansible-managed.conf
   notify:
     - reread systemd configs
+
+- name: disable ISC DHCP IPv6 server
+  service: name=isc-dhcp-server6 enabled=no
+  when: ansible_distribution == 'Ubuntu' and (ansible_distribution_version == '16.04' or ansible_distribution_version == '18.04')
+

--- a/gateways_l2tp_slovenija/handlers/main.yml
+++ b/gateways_l2tp_slovenija/handlers/main.yml
@@ -1,12 +1,6 @@
 - name: load kernel modules
   shell: /etc/init.d/kmod start || true
 
-- name: restart networking
-  shell: systemctl restart networking; if systemctl -q is-active isc-dhcp-server; then systemctl restart isc-dhcp-server; fi; if systemctl -q is-active kea-dhcp4.service; then systemctl restart kea-dhcp4.service; fi; if systemctl -q is-active tunneldigger; then systemctl restart tunneldigger; fi
-
 - name: restart tunneldigger per domain
-  service: name="tunneldigger@{{item.key}}.service" state=restarted
-  with_dict: "{{domaenenliste}}"
-
-- name: restart tunneldigger
-  service: name=tunneldigger.service state=restarted
+  systemd: name="tunneldigger@{{ item.key }}.service" state=restarted
+  with_dict: "{{ domaenenliste }}"

--- a/gateways_l2tp_slovenija/tasks/main.yml
+++ b/gateways_l2tp_slovenija/tasks/main.yml
@@ -1,23 +1,15 @@
 - name: Install dependencies for this role
   apt:
-    pkg: ['bridge-utils', 'ebtables', 'python-pip', 'python-virtualenv', 'libnfnetlink-dev', 'libnetfilter-conntrack-dev', 'libffi-dev']
-    state: present
+    pkg: ['git', 'libnetfilter-conntrack-dev', 'libnfnetlink-dev', 'python-dev', 'python-virtualenv', 'gcc',
+      'libnl-3-dev', 'libffi-dev', 'libevent-dev', 'libnetfilter-conntrack3', 'bridge-utils', 'ebtables', 'iproute2']
   when: domaenenliste is defined
 
-- name: Install Debian 8 dependencies for this role
-  apt:
-    pkg: ['iproute', 'libnetfilter-conntrack3', 'libnetfilter-conntrack-dev', 'python-dev', 'libevent-dev', 'libnl-3-dev', 'gcc']
-    state: present
-  when: ansible_distribution == 'Debian' and ansible_distribution_version == '8' and domaenenliste is defined
-
-- name: Install Ubuntu / Debian 10  dependencies for this role
-  apt:
-    pkg: ['iproute2', 'libnetfilter-conntrack3', 'python-dev', 'libevent-dev', 'libnl-3-dev']
-    state: present
-  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04') or (ansible_distribution == 'Debian' and ansible_distribution_version == '10') and domaenenliste is defined
-
 - name: Get all enabled tunneldigger (domain specific) instances
-  shell: '/bin/ls /etc/systemd/system/multi-user.target.wants/tunneldigger@* | grep -oE "[0-9]+"'
+  shell: |
+    set -o pipefail
+    /bin/ls /etc/systemd/system/multi-user.target.wants/tunneldigger@* | grep -oE "[0-9]+"
+  args:
+    executable: bash
   changed_when: False
   failed_when: False
   check_mode: no
@@ -25,21 +17,23 @@
   when: domaenenliste is defined
 
 - name: Stop and disable obsolete td instances
-  service: name="tunneldigger@{{item}}.service" enabled=no state=stopped
-  with_items: "{{_td_domain_instances.stdout_lines}}"
+  service: name="tunneldigger@{{ item }}.service" enabled=no state=stopped
+  with_items: "{{ _td_domain_instances.stdout_lines }}"
   when: domaenenliste is defined and item not in domaenenliste
 
-- name: Clone tunneldigger 
+- name: Clone tunneldigger
   git:
     repo: https://github.com/wlanslovenija/tunneldigger
     dest: /srv/tunneldigger
-    force: yes
     update: yes
 #    version: 18f365f329795400f4d7a101a6d45bc859100144
   when: domaenenliste is defined
+  tags:
+    - skip_ansible_lint
 
 - name: generate virtualenv.
-  shell: "virtualenv env_tunneldigger"
+  command:
+    "virtualenv env_tunneldigger"
   args:
     chdir: /srv/tunneldigger/
     creates: "/srv/tunneldigger/env_tunneldigger/bin/python"
@@ -52,14 +46,14 @@
   when: domaenenliste is defined
 
 - name: Deploy addif.sh for each domain
-  template: src=addif.sh.j2 dest="/srv/tunneldigger/broker/scripts/addif_domain{{item.key}}.sh" mode=0755
-  with_dict: "{{domaenenliste}}"
+  template: src=addif.sh.j2 dest="/srv/tunneldigger/broker/scripts/addif_domain{{ item.key }}.sh" mode=0755
+  with_dict: "{{ domaenenliste }}"
   when: domaenenliste is defined
 
 - name: Deploy delif.sh for each domain
-  template: src=delif.sh.j2 dest="/srv/tunneldigger/broker/scripts/delif_domain{{item.key}}.sh" mode=0755
-  with_dict: "{{domaenenliste}}"
-  when: 
+  template: src=delif.sh.j2 dest="/srv/tunneldigger/broker/scripts/delif_domain{{ item.key }}.sh" mode=0755
+  with_dict: "{{ domaenenliste }}"
+  when:
     - domaenenliste is defined
 
 - name: Create sperrliste.txt if not exists
@@ -74,9 +68,9 @@
   when: domaenenliste is defined
 
 - name: Deploy l2tp_broker.cfg for each domain
-  template: src="l2tp_broker.cfg.j2" dest="/srv/tunneldigger/broker/l2tp_broker_domain{{item.key}}.cfg"
+  template: src="l2tp_broker.cfg.j2" dest="/srv/tunneldigger/broker/l2tp_broker_domain{{ item.key }}.cfg"
   notify: restart tunneldigger per domain
-  with_dict: "{{domaenenliste}}"
+  with_dict: "{{ domaenenliste }}"
   when:
     - domaenenliste is defined
 
@@ -84,19 +78,20 @@
   copy: src=tunneldigger@.service dest=/etc/systemd/system/tunneldigger@.service
   register: _domain_td_systemd
   notify:
-  - restart tunneldigger per domain
+    - restart tunneldigger per domain
   when:
     - domaenenliste is defined
 
 - name: reload systemd
-  shell: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
   when:
     - domaenenliste is defined
     - _domain_td_systemd.changed
 
 - name: enable all tunneldigger instances
-  service: name="tunneldigger@{{item.key}}.service" enabled=yes
-  with_dict: "{{domaenenliste}}"
+  systemd: name="tunneldigger@{{ item.key }}.service" enabled=yes
+  with_dict: "{{ domaenenliste }}"
   when:
     - domaenenliste is defined
 

--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -60,6 +60,7 @@
   package:
     name: dhcpd-pools
     state: present
+  when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04')
 
 - name: Install check_batip
   copy: "src=check_batip dest='/usr/lib/nagios/plugins/check_batip' owner=root group=root mode=a+x"

--- a/py_respondd/handlers/main.yml
+++ b/py_respondd/handlers/main.yml
@@ -1,8 +1,9 @@
 - name: systemctl reload
-  shell: systemctl daemon-reload
+  systemd:
+    daemon_reload: yes
 
 - name: restart respondd
-  service: 
-    name: py-respondd.service 
+  systemd:
+    name: py-respondd.service
     state: restarted
     enabled: yes

--- a/py_respondd/tasks/main.yml
+++ b/py_respondd/tasks/main.yml
@@ -1,51 +1,46 @@
 ---
 - name: Install dependencies
   apt:
-    pkg: ['python3-pip']
-    state: present
-  when: not (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
+    name: ['python3-pip']
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version == '9')
+
+- name: Install python dependencies
+  pip:
+    name: ['psutil', 'netifaces']
+    executable: pip3
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version == '9')
 
 - name: Install dependencies
   apt:
-    pkg: ['python3-distutils', 'python3-setuptools', 'python3-dev']
-    state: present
+    name: ['python3-distutils', 'python3-setuptools', 'python3-dev', 'python3-psutil', 'python3-netifaces']
   when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04') or
         (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
 
-- name: Install python dependencies
-  apt:
-    pkg: ['python3-psutil', 'python3-netifaces']
-    state: present
-  when: ansible_distribution == 'Debian' and ansible_distribution_version == '10'
-
-- name: Install python dependencies
-  pip: 
-    name: ['psutil', 'netifaces']
-    state: present
-    executable: pip3
-  when: not (ansible_distribution == 'Debian' and ansible_distribution_version == '10')
-
 - name: create systemd files
-  template: 
+  template:
     src: py-respondd.service.j2
     dest: /etc/systemd/system/py-respondd.service
   notify: systemctl reload
 
 - name: Clone py-respondd repo
-  git: 
+  git:
     repo: https://github.com/FreiFunkMuenster/py-respondd.git
     dest: /opt/py-respondd/
     clone: yes
     update: yes
   notify: restart respondd
+  tags:
+    - skip_ansible_lint
 
 - name: create config.json files
-  template: 
+  template:
     src: config.json.j2
     dest: /opt/py-respondd/config.json
   notify: restart respondd
 
 - name: enable py-respondd service
-  service:
+  systemd:
     name: py-respondd.service
     enabled: yes

--- a/py_respondd/templates/py-respondd.service.j2
+++ b/py_respondd/templates/py-respondd.service.j2
@@ -1,5 +1,6 @@
 [Unit]
 Description=The py-respondd server provides data about this node to the local network.
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
Ubuntu 18.04 hat standardmäßig kein ifupdown sondern benutzt Netplan. ifupdown muss nachinstalliert werden damit /etc/network/interfaces.d funktioniert.
Das betrifft diese Rollen:
- backbone_gre_ffrl
- backbone_gre_intern
- gateways_batman
- gateways_gre_upstream
- gateways_gretap
- mapserver_interfaces

Außerdem:
- bird: Debian 8-Unterstützung entfernt, ansible-lint Warnungen behoben
- common: Debian 8-Unterstützung entfernt, ansible-lint Warnungen behoben
- gateways_l2tp_slovenija: unbenutzte Handler entfernt, Debian 8-Unterstützung entfernt, ansible-lint Warnungen behoben
- nrpe: In Ubuntu 16.04 gibt es das Paket dhcp-pools nicht, daher nicht versuchen es zu installieren
- py_respondd: Abhängigkeiten für Ubuntu 16.04 und 18.04 repariert, ansible-lint Warnungen behoben, service erst nach network.target starten
- gateways_dhcp: Nicht benötigten isc-dhcp-server6.service (gibt's nur in Ubuntu, da aber in 16.04 und 18.04) deaktivieren