### PR TITLE
Umbau batman_install

### DIFF
--- a/batman_install/handlers/main.yml
+++ b/batman_install/handlers/main.yml
@@ -1,0 +1,23 @@
+- name: restart batman
+  shell: |
+    set -o pipefail
+    ip -br link show up type batadv | cut -d " " -f1
+  args:
+    executable: bash
+  register: batadv_interfaces
+  notify: ifdown batadv
+
+- name: ifdown batadv
+  command: ifdown --force {{ item }}
+  with_items: "{{ batadv_interfaces.stdout_lines | list }}"
+  notify: rmmod batadv
+
+- name: rmmod batadv
+  modprobe:
+    name: batman-adv
+    state: absent
+  notify: ifup batadv
+
+- name: ifup batadv
+  command: ifup {{ item }}
+  with_items: "{{ batadv_interfaces.stdout_lines | list }}"

--- a/batman_install/tasks/install-deb.yml
+++ b/batman_install/tasks/install-deb.yml
@@ -1,4 +1,4 @@
 - name: batctl-Paket installieren
   apt:
-    pkg: ['batctl']
+    name: ['batctl']
     state: present

--- a/batman_install/tasks/install-legacy-src.yml
+++ b/batman_install/tasks/install-legacy-src.yml
@@ -1,66 +1,66 @@
 - name: Abhängigkeiten installieren
   apt:
-    pkg: ['dkms', 'build-essential', 'linux-headers-{{ansible_kernel}}', 'pkg-config', 'libnl-3-dev', 'libnl-genl-3-dev', 'git']
-    state: present
+    name: ['dkms', 'build-essential', 'linux-headers-{{ ansible_kernel }}', 'pkg-config', 'libnl-3-dev', 'libnl-genl-3-dev', 'git']
 
-- name: create directory for batman-adv
-  file:
-    name: /opt/batman-adv
-    state: directory
-
-- name: Download Gluon maintained batman-adv-legacy 
-  shell: "cd /usr/src && /bin/rm -rf batman-adv-2013.4.0 && git clone https://github.com/freifunk-gluon/batman-adv-legacy.git batman-adv-2013.4.0" 
-  register: getbatman
-
-# Gluon's batman-adv-legacy already has a working dkms.conf
-#- name: configure dkms
-#  template: 
-#    src: dkms.conf
-#    dest: /usr/src/batman-adv-{{batman.version}}/dkms.conf
-#
-- stat: 
-    path: /lib/modules/{{ansible_kernel}}/updates/dkms/batman-adv.ko
-  register: batman_adv_file
+- name: Gluon-verwalteten Batman-Quellcode herunterladen
+  git:
+    repo: "https://github.com/freifunk-gluon/batman-adv-legacy.git"
+    dest: "/usr/src/batman-adv-2013.4.0"
+    force: yes
+  tags:
+    - skip_ansible_lint
 
 - name: Batman bauen
-  shell: "(dkms status -m batman-adv -v {{batman.version}} | grep batman-adv || dkms add -m batman-adv -v {{batman.version}}) && dkms build -m batman-adv -v {{batman.version}} && dkms install -m batman-adv -v {{batman.version}} --force"
-  when:
-    - batman_adv_file.stat.exists == False or getbatman.changed
+  shell: |
+    set -o pipefail
+    (dkms status -m batman-adv -v {{ batman.version }} | grep batman-adv || dkms add -m batman-adv -v {{ batman.version }}) && \
+    dkms build -m batman-adv -v {{ batman.version }} && dkms install -m batman-adv -v {{ batman.version }} --force
+  args:
+    executable: bash
+  tags:
+    - skip_ansible_lint
+  notify: restart batman
 
 # batctl
-- name: create directory for batctl
-  file:
-    name: /opt/batctl
-    state: directory
-
-- name: get batctl
-  get_url:
-    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{batman.version}}/batctl-{{batman.version}}.tar.gz"
-    dest: /opt/batctl/batctl-{{batman.version}}.tar.gz
-  register: getbatctl
-
-- name: batctl-Quellen und entpacken
-  unarchive:
-    src: /opt/batctl/batctl-{{batman.version}}.tar.gz
-    dest: /usr/src
-    remote_src: True
-  when:
-    - getbatctl.changed
-
-- stat: path=/usr/local/sbin/batctl
+- name: Prüfe ob batctl bereits existiert
+  stat: path=/usr/local/sbin/batctl
   register: batctl
 
-- name: batctl Version prüfen
-  shell: '{{batctl.stat.path}} -v | grep -oE "batctl [0-9]+\.[0-9]+(\.[0-9]+)?"'
-  when: 
-    - batctl.stat.exists == True
-  changed_when: False
+- name: batctl-Version prüfen
+  shell: |
+    set -o pipefail
+    {{ batctl.stat.path }} -v | grep -oE "[0-9]+\.[0-9]+(\.[0-9]+)?"
+  args:
+    executable: bash
+  when: batctl.stat.exists
+  changed_when: false
   register: batctl_version
   check_mode: no
 
-- name: batctl bauen
-  shell: "make && make install"
+- name: Verzeichnis erstellen für Quellcode von batctl
+  file:
+    name: /opt/batctl
+    state: directory
+  when: not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version
+
+- name: batctl-Quellcode herunterladen
+  get_url:
+    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{ batman.version }}/batctl-{{ batman.version }}.tar.gz"
+    dest: /opt/batctl/batctl-{{ batman.version }}.tar.gz
+  when: not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version
+
+- name: batctl-Quellcode entpacken
+  unarchive:
+    src: /opt/batctl/batctl-{{ batman.version }}.tar.gz
+    dest: /usr/src
+    remote_src: True
+  when: not ansible_check_mode and (not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version)
+
+- name: batctl bauen und installieren
+  command: "{{ item }}"
+  with_items:
+    - make
+    - make install
   args:
-    chdir: /usr/src/batctl-{{batman.version}}
-  when:
-    - batctl.stat.exists == False or batctl_version.stdout_lines[0] != "batctl {{batman.version}}"
+    chdir: /usr/src/batctl-{{ batman.version }}
+  when: not ansible_check_mode and (not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version)

--- a/batman_install/tasks/install-src.yml
+++ b/batman_install/tasks/install-src.yml
@@ -1,75 +1,79 @@
 - name: Abhängigkeiten installieren
   apt:
-    pkg: ['dkms', 'build-essential', 'linux-headers-{{ansible_kernel}}', 'pkg-config', 'libnl-3-dev', 'libnl-genl-3-dev']
+    name: ['dkms', 'build-essential', 'linux-headers-{{ ansible_kernel }}', 'pkg-config', 'libnl-3-dev', 'libnl-genl-3-dev']
     state: present
 
-- name: create directory for batman-adv
+- name: Verzeichnis erstellen für Quellcode von batman-adv
   file:
     name: /opt/batman-adv
     state: directory
 
-- name: Download Batman 
+- name: Batman-Quellecode herunterladen
   get_url:
-    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{batman.version}}/batman-adv-{{batman.version}}.tar.gz"
-    dest: /opt/batman-adv/batman-adv-{{batman.version}}.tar.gz
-  register: getbatman
+    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{ batman.version }}/batman-adv-{{ batman.version }}.tar.gz"
+    dest: /opt/batman-adv/batman-adv-{{ batman.version }}.tar.gz
 
-- name: batman-Quellen entpacken
+- name: Batman-Quellcode entpacken
   unarchive:
-    src: /opt/batman-adv/batman-adv-{{batman.version}}.tar.gz
+    src: /opt/batman-adv/batman-adv-{{ batman.version }}.tar.gz
     dest: /usr/src
     remote_src: True
-  when: 
-    - getbatman.changed
+  when: not ansible_check_mode
 
-- name: configure dkms
-  template: 
+- name: DKMS konfigurieren
+  template:
     src: dkms.conf
-    dest: /usr/src/batman-adv-{{batman.version}}/dkms.conf
-
-- stat: 
-    path: /lib/modules/{{ansible_kernel}}/updates/dkms/batman-adv.ko
-  register: batman_adv_file
+    dest: /usr/src/batman-adv-{{ batman.version }}/dkms.conf
 
 - name: Batman bauen
-  shell: "dkms add -m batman-adv -v {{batman.version}} && dkms build -m batman-adv -v {{batman.version}} && dkms install -m batman-adv -v {{batman.version}} --force"
-  when:
-    - batman_adv_file.stat.exists == False or getbatman.changed
+  command: "{{ item }}"
+  with_items:
+    - dkms add -m batman-adv -v {{ batman.version }}
+    - dkms build -m batman-adv -v {{ batman.version }}
+    - dkms install -m batman-adv -v {{ batman.version }} --force
+  notify: restart batman
+  changed_when: false
 
 # batctl
-- name: create directory for batctl
-  file:
-    name: /opt/batctl
-    state: directory
-
-- name: get batctl
-  get_url:
-    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{batman.version}}/batctl-{{batman.version}}.tar.gz"
-    dest: /opt/batctl/batctl-{{batman.version}}.tar.gz
-  register: getbatctl
-
-- name: batctl-Quellen und entpacken
-  unarchive:
-    src: /opt/batctl/batctl-{{batman.version}}.tar.gz
-    dest: /usr/src
-    remote_src: True
-  when:
-    - getbatctl.changed
-
-- stat: path=/usr/local/sbin/batctl
+- name: Prüfe ob batctl bereits existiert
+  stat: path=/usr/local/sbin/batctl
   register: batctl
 
-- name: batctl Version prüfen
-  shell: '{{batctl.stat.path}} -v | grep -oE "batctl [0-9]+\.[0-9]+"'
-  when: 
-    - batctl.stat.exists == True
-  changed_when: False
+- name: batctl-Version prüfen
+  shell: |
+    set -o pipefail
+    {{ batctl.stat.path }} -v | grep -oE "[0-9]+\.[0-9]+(\.[0-9]+)?"
+  args:
+    executable: bash
+  when: batctl.stat.exists
+  changed_when: false
   register: batctl_version
   check_mode: no
 
-- name: batctl bauen
-  shell: "make && make install"
+- name: Verzeichnis erstellen für Quellcode von batctl
+  file:
+    name: /opt/batctl
+    state: directory
+  when: not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version
+
+- name: batctl-Quellcode herunterladen
+  get_url:
+    url: "https://downloads.open-mesh.org/batman/releases/batman-adv-{{ batman.version }}/batctl-{{ batman.version }}.tar.gz"
+    dest: /opt/batctl/batctl-{{ batman.version }}.tar.gz
+  when: not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version
+
+- name: batctl-Quellcode entpacken
+  unarchive:
+    src: /opt/batctl/batctl-{{ batman.version }}.tar.gz
+    dest: /usr/src
+    remote_src: True
+  when: not ansible_check_mode and (not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version)
+
+- name: batctl bauen und installieren
+  command: "{{ item }}"
+  with_items:
+    - make
+    - make install
   args:
-    chdir: /usr/src/batctl-{{batman.version}}
-  when:
-    - batctl.stat.exists == False or batctl_version.stdout_lines[0] != "batctl {{batman.version}}"
+    chdir: /usr/src/batctl-{{ batman.version }}
+  when: not ansible_check_mode and (not batctl.stat.exists or batctl_version.stdout_lines[0] != batman.version)

--- a/batman_install/tasks/main.yml
+++ b/batman_install/tasks/main.yml
@@ -1,6 +1,10 @@
 # installierte batman-Version prüfen
 - name: Prüfe installierte batman-adv-Version
-  shell: "modinfo -F version batman-adv"
+  shell: |
+    set -o pipefail
+    modinfo -F version batman-adv | grep -oE '^[0-9\.]+'
+  args:
+    executable: bash
   register: installed_batman_version
   when: batman.version is defined and batman.version
   changed_when: False
@@ -13,7 +17,11 @@
 
 # installierte batman-Version erneut prüfen
 - name: Prüfe batman-adv-Version des Kernels
-  shell: "modinfo -F version batman-adv"
+  shell: |
+    set -o pipefail
+    modinfo -F version batman-adv | grep -oE '^[0-9\.]+'
+  args:
+    executable: bash
   register: installed_batman_version
   when: batman.version is defined and batman.version != "kernel" and
         (installed_batman_version.stdout is defined and installed_batman_version.stdout != batman.version)

--- a/batman_install/tasks/remove-deb.yml
+++ b/batman_install/tasks/remove-deb.yml
@@ -1,4 +1,4 @@
 - name: batctl-Paket deinstallieren
   apt:
-    pkg: ['batctl']
+    name: ['batctl']
     state: absent

--- a/batman_install/tasks/remove-src.yml
+++ b/batman_install/tasks/remove-src.yml
@@ -10,20 +10,20 @@
 
 # Evtl. vorhandenes batman-adv-DKMS-Modul deinstallieren
 - name: Prüfe ob batman-adv als DKMS-Modul installiert wurde
-  shell: dkms status batman-adv -k {{ ansible_kernel }} | grep -Eo '[[:digit:]]{4}\.[[:digit:]](\.[[:digit:]])?' || true
+  shell: |
+    set -o pipefail
+    dkms status batman-adv -k {{ ansible_kernel }} | grep -Eo '[[:digit:]]{4}\.[[:digit:]](\.[[:digit:]])?' || true
+  args:
+    executable: bash
   register: dkms_version_batman
   when: stat_dkms.stat.exists
   changed_when: False
   check_mode: no
 
 - name: DKMS-Modul batman-adv entfernen
-  shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} -k {{ ansible_kernel }}"
-  when: (batman.version is not defined or batman.version != "2013.4.0") and stat_dkms.stat.exists and dkms_version_batman.stdout
-
-- name: Legacy DKMS-Modul batman-adv entfernen
-  shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} --all"
-  when: (batman.version is defined and batman.version == "2013.4.0") and stat_dkms.stat.exists and dkms_version_batman.stdout
-
+  shell: "dkms remove batman-adv/{{ dkms_version_batman.stdout }} -k {{ ansible_kernel }} || rm -rf /var/lib/dkms/batman-adv/{{ dkms_version_batman.stdout }}"
+  when: stat_dkms.stat.exists and dkms_version_batman.stdout
+  notify: restart batman
 
 # batctl
 - name: /usr/local/sbin/batctl löschen


### PR DESCRIPTION
- Überflüssige Schritte entfernt
- ansible-lint-Warnungen behoben
- Verhalten bei Ansible check_mode repariert
- Bei Versionswechsel des batman-adv-Kernelmoduls wird das neue Modul geladen und die Batman-Interfaces neu gestartet
