### PR TITLE
gateways_fastd: Standardport für Domäne überschreiben, Keys in host-Variablen, und Kleinkram

### DIFF
--- a/gateways_fastd/tasks/main.yml
+++ b/gateways_fastd/tasks/main.yml
@@ -4,7 +4,7 @@
 - name: check if fastd needs to be installed
   set_fact:
      fastd_on_this_gw: true
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
 
 - name: install fastd (vpn daemon) and haveged (entropy daemon)
@@ -15,7 +15,11 @@
   when: fastd_on_this_gw is defined and fastd_on_this_gw
 
 - name: Get all enabled fastd instances
-  shell: '/bin/ls /etc/systemd/system/multi-user.target.wants/fastd@* | grep -oE "[0-9]+"'
+  shell: |
+    set -o pipefail
+    /bin/ls /etc/systemd/system/multi-user.target.wants/fastd@* | grep -oE "[0-9]+"
+  args:
+    executable: bash
   changed_when: False
   failed_when: False
   check_mode: no
@@ -27,11 +31,13 @@
     enabled: no
     state: stopped
   with_items: "{{ _fastd_domain_instances.stdout_lines }}"
-  when: domaenenliste is defined and item not in domaenenliste or not domaenenliste[item].fastd
+  when: domaenenliste is defined and item not in domaenenliste or
+        (domaenenliste[item].fastd is defined and not domaenenliste[item].fastd) or
+        (domaenenliste[item].fastd is undefined and domaenenliste[item].fastd_key is undefined)
 
 - name: remove fastd (vpn daemon) and haveged (entropy daemon)
   apt:
-    pkg: ['fastd', 'haveged']
+    name: ['fastd', 'haveged']
     state: absent
   when: fastd_on_this_gw is not defined or not fastd_on_this_gw
 
@@ -39,25 +45,47 @@
   file:
     path: /etc/fastd/{{ item.key }}
     state: directory
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
 
 - name: create keys directories
   file:
     path: /etc/fastd/{{ item.key }}/keys
     state: directory
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
+  with_dict: "{{ domaenenliste }}"
+
+- name: write private key to seperate keyfiles, if fastd key is defined as host variable
+  template:
+    src: secret.key.j2
+    dest: /etc/fastd/{{ item.key }}/keys/secret.key
+    owner: root
+    group: root
+    mode: 0600
+  when: item.value.fastd_key is defined and not (item.value.fastd is defined and not item.value.fastd)
+  vars:
+    secretkey: "{{ item.value.fastd_key.secret }}"
+  with_dict: "{{ domaenenliste }}"
+
+- name: write public private key to seperate keyfiles, if fastd key is defined as host variable
+  template:
+    src: public.key.j2
+    dest: /etc/fastd/{{ item.key }}/keys/public.key
+  when: item.value.fastd_key is defined and not (item.value.fastd is defined and not item.value.fastd)
+  vars:
+    publickey: "{{ item.value.fastd_key.public }}"
   with_dict: "{{ domaenenliste }}"
 
 # generate new fastd keypair if no fastd_key file exists
 # new key will only be generated, if no secret,key file exists (public key doesn't matter)
 - name: generate fastd key (if not exists)
-  shell: fastd --generate-key
+  command: fastd --generate-key
   register: fastd_key_generated
   args:
     creates: /etc/fastd/{{ item.key }}/keys/secret.key
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) and item.value.fastd_key is undefined
   with_dict: "{{ domaenenliste }}"
+  check_mode: no
   notify:
     - restart fastd per domain
 
@@ -69,6 +97,8 @@
     group: root
     mode: 0600
   when: item.changed
+  vars:
+    secretkey: "{{ item.stdout_lines[0]|replace('Secret: ','') }}"
   with_items: "{{ fastd_key_generated.results }}"
 
 - name: write public private key to seperate keyfiles, if new fastd key is generated
@@ -76,13 +106,15 @@
     src: public.key.j2
     dest: /etc/fastd/{{ item.item.key }}/keys/public.key
   when: item.changed
+  vars:
+    publickey: "{{ item.stdout_lines[1]|replace('Public: ','') }}"
   with_items: "{{ fastd_key_generated.results }}"
 
 - name: create dummy peer directory
   file:
     path: /etc/fastd/{{ item.key }}/peers
     state: directory
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
 
 # create dummy peer file
@@ -90,7 +122,7 @@
   template:
     src: dummy.j2
     dest: /etc/fastd/{{ item.key }}/peers/dummy
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
 
 # create fastd config
@@ -100,7 +132,7 @@
     dest: /etc/fastd/{{ item.key }}/fastd.conf
   notify:
     - restart fastd per domain
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
 
 - name: create verify directory
@@ -124,7 +156,7 @@
   file:
     path: /var/freifunk/gateway-{{ freifunk.kurzname }}/fastd/blacklist
     state: touch
-  when: blacklist_file.stat.exists == False and fastd_on_this_gw is defined and fastd_on_this_gw
+  when: not blacklist_file.stat.exists and fastd_on_this_gw is defined and fastd_on_this_gw
 
 - name: status.pl nach /root kopieren
   copy:
@@ -172,7 +204,7 @@
     name: fastd@{{ item.key }}
     enabled: yes
     masked: no
-  when: item.value.fastd is defined and item.value.fastd
+  when: (item.value.fastd is defined and item.value.fastd) or (item.value.fastd is undefined and item.value.fastd_key is defined)
   with_dict: "{{ domaenenliste }}"
   notify:
     - restart fastd per domain

--- a/gateways_fastd/templates/fastd.conf.j2
+++ b/gateways_fastd/templates/fastd.conf.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 
 # Bind to a fixed address and port, IPv4 and IPv6
-bind {{ ansible_default_ipv4.address }}:{{ fastd.port_base + (item.key | int) }} interface "{{ ansible_default_ipv4.interface }}";
+bind {{ ansible_default_ipv4.address }}:{{ domaenen[item.key].fastd_port_forced | default(fastd.port_base + (item.key | int)) }} interface "{{ ansible_default_ipv4.interface }}";
 
 {% if ansible_default_ipv6 %}
-bind [{{ ansible_default_ipv6.address }}]:{{ fastd.port_base + (item.key | int) }} interface "{{ ansible_default_ipv6.interface }}";
+bind [{{ ansible_default_ipv6.address }}]:{{ domaenen[item.key].fastd_port_forced | default(fastd.port_base + (item.key | int)) }} interface "{{ ansible_default_ipv6.interface }}";
 {% endif %}
 
 # Set the user, fastd will work as
@@ -50,9 +50,4 @@ on verify "
 on up "
   # Add fastd interface to bridge, then enable it
   ip link set dev $INTERFACE master br{{ item.key }} && ip link set dev $INTERFACE up
-";
-
-on down "
-  # Remove fastd interface from bridge
-  ip link set dev $INTERFACE nomaster
 ";

--- a/gateways_fastd/templates/public.key.j2
+++ b/gateways_fastd/templates/public.key.j2
@@ -1,1 +1,3 @@
-key "{{ item.stdout_lines[1]|replace("Public: ","") }}";
+# {{ ansible_managed }}
+
+key "{{ publickey }}";

--- a/gateways_fastd/templates/secret.key.j2
+++ b/gateways_fastd/templates/secret.key.j2
@@ -1,1 +1,3 @@
-secret "{{ item.stdout_lines[0]|replace("Secret: ","") }}";
+# {{ ansible_managed }}
+
+secret "{{ secretkey }}";


### PR DESCRIPTION
- Zu Dateien mit Secret- und Public-Key oben den Kommentar "Ansible managed" hinzugefügt

- Nicht mehr versuchen, beim Beenden von fastd das fastd-Interface aus den Domänen-Bridges zu entfernen, das passiert automatisch.

- Erlaube Überschreiben des mit fastd.port_base+Domänennummer errechneten fastd-Ports durch Setzen von `domaenen.[<DOMÄNE>].fastd_port_forced=<PORT>`

	Beispiel:
	```
	fastd:
	  port_base: 10000

	domaenen:
	  "10":
		name: "Innenstadt"
		[...]
	  "11":
		name: "Nordstadt"
		fastd_port_forced: 6128
	  "12":
		name: "Südstadt"
		[...]
	```
	fastd für Domäne 10 lauscht dann auf Port 10010, für Domäne 11 auf 6128, für Domäne 12 auf 10012

- fastd-Keys können in "domaenenliste" für jede Domäne angegeben werden:
  `domaenenliste.<DOMÄNE>.fastd_key.secret: "SECRETKEY"`
  `domaenenliste.<DOMÄNE>.fastd_key.public: "PUBLICKEY"`

	Beispiel:
	```
	domaenenliste:
	  "17":
	    dhcp_start: 10.17.80.0
	    dhcp_ende: 10.17.95.255
	    fastd: true
	    fastd_key:
	      secret: "5f06e8776dcb8916da72e02b7bc7fde27ebdde570befb9254e7c93eceb75fcc1"
	      public: "775c9aa513227e580253df4c7e4cd2c541daeaba8f3119e548530814b0ac2a8a"
	```
  fastd wird nur dann für eine Domäne aktiviert, wenn der Schlüssel "fastd" exisitiert und auf "true" gesetzt ist, oder wenn der Schlüssel "fastd_key" exisitiert.
  Ist "fastd" auf "false" gesetzt, wird fastd nicht aktiviert, ganz gleich ob "fastd_key" existiert.
  Sprich: Wenn man die Keys hier angibt muss man nicht noch extra "fastd: true" schreiben.