### PR TITLE
Gesammelte Änderungen

### DIFF
--- a/backbone_gre_intern/templates/gre_interbackbone.j2
+++ b/backbone_gre_intern/templates/gre_interbackbone.j2
@@ -14,11 +14,12 @@ iface bck-{{host}} inet static
         pre-up ip link set $IFACE up multicast on
         post-up ip rule add iif $IFACE table ffnet
         pre-down ip rule del iif $IFACE table ffnet ||:
+
 iface bck-{{host}} inet6 static
 {% if hostvars[host].vm_id < vm_id %}
-        address 2a03:2260:115:ffa1::{{hostvars[host].vm_id}}:{{vm_id}}:0
+        address {{ipv6backbone64prefixstr}}{{hostvars[host].vm_id}}:{{vm_id}}:0
 {% else %}
-        address 2a03:2260:115:ffa1::{{vm_id}}:{{hostvars[host].vm_id}}:1
+        address {{ipv6backbone64prefixstr}}{{vm_id}}:{{hostvars[host].vm_id}}:1
 {% endif %}
         netmask 127
         post-up ip -6 rule add iif $IFACE table ffnet

--- a/batman_install/tasks/main.yml
+++ b/batman_install/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Prüfe installierte batman-adv-Version
   shell: |
     set -o pipefail
-    modinfo -F version batman-adv | grep -oE '^[0-9\.]+'
+    modinfo -F version batman-adv | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?'
   args:
     executable: bash
   register: installed_batman_version
@@ -19,7 +19,7 @@
 - name: Prüfe batman-adv-Version des Kernels
   shell: |
     set -o pipefail
-    modinfo -F version batman-adv | grep -oE '^[0-9\.]+'
+    modinfo -F version batman-adv | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?'
   args:
     executable: bash
   register: installed_batman_version

--- a/bird/templates/bird.conf.j2
+++ b/bird/templates/bird.conf.j2
@@ -5,6 +5,30 @@ router id {{ vm_id }};
 
 table ffnet;
 
+function is_default() {
+	return (net ~ [0.0.0.0/0]);
+};
+
+filter freifunk {
+{% if ffrl_tun is defined %}
+	# FFRL
+	if net ~ [185.66.192.0/22+] then accept;
+{% endif %}
+{% if ffnw_tun is defined %}
+	# FFNW
+	if net ~ [185.197.132.0/24+] then accept;
+{% endif %}
+
+	if net ~ [10.0.0.0/8+] then accept;
+{% if not ffrl_tun is defined and not ffnw_tun is defined %}
+	if net ~ [0.0.0.0/0] then accept;
+{% endif %}
+
+	# interne Tunnel-IPs
+	if net ~ [192.168.0.0/16+] then accept;
+	reject;
+};
+
 protocol kernel 'kernel_ffnet' {
         scan time 20;
         import all;
@@ -70,34 +94,52 @@ protocol static dhcp_Bereich {
 }
 {% endif %}
 
-filter freifunk {
-{% if ffrl_tun is defined %}
-	# FFRL
-	if net ~ [185.66.192.0/22+] then accept;
+filter hostroute {
+{% if ffrl_nat_ip is defined %}
+	if net ~ {{ffrl_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-{% if ffnw_tun is defined %}
-	# FFNW
-	if net ~ [185.197.132.0/24+] then accept;
+{% if ffnw_nat_ip is defined %}
+	if net ~ {{ffnw_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-
-	if net ~ [10.0.0.0/8+] then accept;
-{% if not ffrl_tun is defined and not ffnw_tun is defined %}
-	if net ~ [0.0.0.0/0] then accept;
+{% if ospf_nat_ip is defined %}
+	if net ~ {{ospf_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-
-	# interne Tunnel-IPs
-	if net ~ [192.168.0.0/16+] then accept;
 	reject;
 };
 
+{% if ospf_nat_ip is defined %}
+protocol ospf upstream {
+	table ffnet;
+	import where is_default();
+	export filter hostroute;
+{% if ospf_nat_instanceid is defined %}
+	instance id {{ospf_nat_instanceid}};
+{% endif %}
 
-protocol ospf {
+{% if ospf_nat_area is defined %}
+	area {{ospf_nat_area}} {
+{% else %}
+	area 0.0.0.0 {
+{% endif %}
+	    interface "{{ansible_default_ipv4.interface}}" {
+                cost 10;
+{% if ospf_nat_options is defined %}
+            	{{ospf_nat_options}}
+{% endif %}
+	    };
+	    interface "lo" { stub; };
+	};
+};
+{% endif %}
+
+protocol ospf backbone {
 	table ffnet;
 	import filter freifunk;
 	export filter {
 		if net ~ [192.168.0.0/16+] then reject;
 		accept;
 	};
+
 	area 0.0.0.0 {
 		interface "bat*" {
 			stub;
@@ -110,6 +152,7 @@ protocol ospf {
 {% endif %}
 {% endfor %}
 		interface "bck-*";
+
 		interface "lo" {
 			stub;
 		};
@@ -131,21 +174,7 @@ protocol static {
         export none;
 };
 
-filter hostroute {
-{% if ffrl_nat_ip is defined %}
-	if net ~ {{ffrl_nat_ip | ipaddr('address')}}/32 then accept;
-{% endif %}
-{% if ffnw_nat_ip is defined %}
-	if net ~ {{ffnw_nat_ip | ipaddr('address')}}/32 then accept;
-{% endif %}
-	reject;
-};
-
 {% if ffrl_tun is defined or ffnw_tun is defined %}
-function is_default() {
-	return (net ~ [0.0.0.0/0]);
-};
-
 template bgp uplink {
 	table ffnet;
 	local as {{ff_network.as_number}};

--- a/bird/templates/bird6.conf.j2
+++ b/bird/templates/bird6.conf.j2
@@ -5,6 +5,10 @@ router id {{ vm_id }};
 
 table ffnet;
 
+function is_default() {
+	return (net ~ [::/0]);
+};
+
 filter freifunk {
 	if net ~ {{ff_network.v6_network}} then accept;
 {% if not ffrl_tun is defined %}
@@ -13,7 +17,7 @@ filter freifunk {
 	reject;
 }
 
-protocol kernel {
+protocol kernel  'kernel_ffnet' {
 	scan time 20;
 	import all;
 	export all;
@@ -40,6 +44,14 @@ protocol radv {
 };
 {% endif %}
 
+filter subnetv6 {
+{% if domaenenliste is defined %}
+{% for domaene in domaenenliste|dictsort %}
+	if net = {{domaenen[domaene[0]].ffv6_network}} then accept;
+{% endfor %}
+{% endif %}
+	reject;
+};
 
 protocol bfd {
 	table ffnet;
@@ -54,10 +66,43 @@ protocol device {
 	scan time 10;
 };
 
-protocol ospf {
+{% if ipv6_direkt_ausleiten is defined and ipv6_direkt_ausleiten %}
+protocol static v6localexit {
+        table ffnet;
+        preference 1000;
+        route ::/0 via {{ ansible_default_ipv6.gateway }};
+};
+{% endif %}
+
+{% if ipv6_direkt_ausleiten is defined and ipv6_direkt_ausleiten %}
+protocol ospf upstream {
+	table ffnet;
+	import where is_default();
+	export filter subnetv6;
+{% if ospf_nat_instanceid is defined %}
+	instance id {{ospf_nat_instanceid}};
+{% endif %}
+
+{% if ospf_nat_area is defined %}
+	area {{ospf_nat_area}} {
+{% else %}
+	area 0.0.0.0 {
+{% endif %}
+	    interface "{{ansible_default_ipv4.interface}}" {
+                cost 10;
+{% if ospf_nat_options is defined %}
+            	{{ospf_nat_options}}
+{% endif %}
+	    };
+	};
+};
+{% endif %}
+
+protocol ospf backbone {
 	table ffnet;
 	import filter freifunk;
 	export all;
+
 	area 0.0.0.0 {
 		interface "bat*" {
 			stub;
@@ -70,16 +115,13 @@ protocol ospf {
 {% endif %}
 {% endfor %}
 		interface "bck-*";
+
 {% if ffrl_tun is defined %}
 		interface "lo" {
 			stub;
 		};
 {% endif %}
 	};
-};
-
-function is_default() {
-	return (net ~ [::/0]);
 };
 
 filter export_to_upstream_filter {
@@ -92,6 +134,7 @@ protocol static static_Gesamtnetzwerk {
 	route {{ff_network.v6_network}} reject;
 };
 
+{% if ffrl_tun is defined or ffnw_tun is defined %}
 {% if domaenenliste is defined %}
 {% for domaene in domaenenliste|dictsort %}
 protocol static static_domaene{{domaene[0]}} {
@@ -99,6 +142,7 @@ protocol static static_domaene{{domaene[0]}} {
 	route {{domaenen[domaene[0]].ffv6_network | regex_replace('..::/\d+$','00::/56')}} reject;
 };
 {% endfor %}
+{% endif %}
 {% endif %}
 {% if dhcp is defined %}
 protocol static 'static_{{inventory_hostname_short}}' {
@@ -159,9 +203,9 @@ template bgp internal {
 {% if hostvars[host].vm_id != vm_id %}
 protocol bgp ibgp_{{host|regex_replace('-','_')}} from internal {
 {% if hostvars[host].vm_id < vm_id %}
-	neighbor 2a03:2260:115:ffa1::{{hostvars[host].vm_id}}:{{vm_id}}:1 as {{ff_network.as_number}};
+	neighbor {{ipv6backbone64prefixstr}}{{hostvars[host].vm_id}}:{{vm_id}}:1 as {{ff_network.as_number}};
 {% else %}
-	neighbor 2a03:2260:115:ffa1::{{vm_id}}:{{hostvars[host].vm_id}}:0 as {{ff_network.as_number}};
+	neighbor {{ipv6backbone64prefixstr}}{{vm_id}}:{{hostvars[host].vm_id}}:0 as {{ff_network.as_number}};
 {% endif %}
 {% if hostvars[host].hoster|default('unknown') != hoster|default('unknown') %}
 	import filter {

--- a/collectd/tasks/main.yml
+++ b/collectd/tasks/main.yml
@@ -84,7 +84,7 @@
   template: src=kea.py.j2 dest=/opt/collectd-python/kea.py
   notify:
     - restart collectd
-  when: collectd.collect_dhcp and domaenenliste is defined
+  when: collectd.collect_dhcp and (domaenenliste is defined and dhcp_type == 'kea')
 
 - name: deploy ipv4ipv6.py
   template: src=ipv4ipv6.py.j2 dest=/opt/collectd-python/ipv4ipv6.py

--- a/gateways_bind/templates/named.conf.ffnet.j2
+++ b/gateways_bind/templates/named.conf.ffnet.j2
@@ -13,10 +13,12 @@ view "domaene-{{domaene[0]}}" {
 {% if is_external_nameserver is defined and is_external_nameserver %}
 	include "/etc/bind/named.conf.tld";
 {% endif %}
+{% if have_local_kurzname_zone is defined and have_local_kurzname_zone %}
 	zone "{{freifunk.kurzname}}." {
 		type master;
 		file "/etc/bind/db.domaene-{{domaene[0]}}.ffnet";
 	};
+{% endif %}
 };
 {% endfor %}
 {% if is_external_nameserver is defined and is_external_nameserver %}

--- a/gateways_fastd/tasks/main.yml
+++ b/gateways_fastd/tasks/main.yml
@@ -67,7 +67,7 @@
     secretkey: "{{ item.value.fastd_key.secret }}"
   with_dict: "{{ domaenenliste }}"
 
-- name: write public private key to seperate keyfiles, if fastd key is defined as host variable
+- name: write public key to seperate keyfiles, if fastd key is defined as host variable
   template:
     src: public.key.j2
     dest: /etc/fastd/{{ item.key }}/keys/public.key

--- a/gateways_gre_upstream/templates/lo.j2
+++ b/gateways_gre_upstream/templates/lo.j2
@@ -12,9 +12,15 @@ iface lo inet loopback
         up ip rule add from {{ ffnw_nat_ip }} table ffnet
         up ip rule add iif lo table ffnet suppress_prefixlength 0
         up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
+{% elif ospf_nat_ip is defined %}
+        up ip address add {{ ospf_nat_ip }} dev lo
+        up ip rule add from {{ ospf_nat_ip }} table ffnet
+        up ip rule add iif lo table ffnet suppress_prefixlength 0
+        up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
 {% else %}
         up ip address add 10.0.0.{{vm_id}} dev lo
         up ip rule add from 10.0.0.{{vm_id}} table ffnet
         up ip rule add iif lo table ffnet suppress_prefixlength 0
         up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
 {% endif %}
+

--- a/gateways_l2tp_slovenija/tasks/main.yml
+++ b/gateways_l2tp_slovenija/tasks/main.yml
@@ -27,6 +27,7 @@
     dest: /srv/tunneldigger
     update: yes
 #    version: 18f365f329795400f4d7a101a6d45bc859100144
+    version: f5bb0efb19468e8dfd0726b40c1431f5c526b3b7
   when: domaenenliste is defined
   tags:
     - skip_ansible_lint

--- a/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
@@ -2,7 +2,7 @@
 ; IP address the broker will listen and accept tunnels on
 address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
-port={{20000 + (item.key | int)}}
+port={{tunneldigger.control_port|default('20000') + (item.key | int)}}
 ; Interface with that IP address
 interface={{ansible_default_ipv4.interface}}
 ; Maximum number of tunnels that will be allowed by the broker
@@ -10,7 +10,7 @@ max_tunnels={{ tunneldigger.max_tunnels - 1 }}
 ; Tunnel port base. This port is not visible to clients, but must be free on the server.
 ; This port is used by the actual l2tp tunnel, but tunneldigger sets up NAT rules so that clients
 ; can keep using the control port.
-port_base={{tunneldigger.port_base}}
+port_base={{tunneldigger.port_base|default('20000')}}
 ; Tunnel id base
 tunnel_id_base={% for domaene in domaenenliste %}{% if domaene == item.key %}{{loop.index * tunneldigger.max_tunnels - tunneldigger.max_tunnels}}{% endif %}{% endfor %}
 

--- a/iptables/templates/rules.v4.j2
+++ b/iptables/templates/rules.v4.j2
@@ -3,9 +3,9 @@
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
+-A FORWARD -p tcp --dport 25 -j DROP
 :OUTPUT ACCEPT [0:0]
 -A INPUT -p udp -m udp --dport 111 -j DROP
-
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]
@@ -14,6 +14,10 @@ COMMIT
 :POSTROUTING ACCEPT [0:0]
 {% if ipv4_direkt_ausleiten is defined and ipv4_direkt_ausleiten %}
 -A POSTROUTING -o {{ansible_default_ipv4.interface}} -j SNAT --to-source {{ansible_default_ipv4.address}}
+{% elif ospf_nat_ip is defined %}
+{% for domaene in domaenenliste|dictsort %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -j SNAT -s {{domaenen[domaene[0]].ffv4_network}} --to-source {{ospf_nat_ip | ipaddr('address')}}
+{% endfor %}
 {% elif ffrl_tun is defined and ffrl_nat_ip is defined %}
 -A POSTROUTING -o tun-ffrl+ -j SNAT --to-source {{ffrl_nat_ip | ipaddr('address')}}
 {% elif ffnw_tun is defined and ffnw_nat_ip is defined %}
@@ -49,5 +53,10 @@ COMMIT
 :POSTROUTING ACCEPT [0:0]
 {% if ffrl_tun is defined or ffnw_tun is defined %}
 -A POSTROUTING -o tun-+ -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
+{% elif ospf_nat_ip is defined %}
+{% for domaene in domaenenliste|dictsort %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -s {{domaenen[domaene[0]].ffv4_network}} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
+{% endfor %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -s {{ospf_nat_ip | ipaddr('address')}} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
 {% endif %}
 COMMIT

--- a/iptables/templates/rules.v6.j2
+++ b/iptables/templates/rules.v6.j2
@@ -3,6 +3,7 @@
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
+-A FORWARD -p tcp --dport 25 -j DROP
 :OUTPUT ACCEPT [0:0]
 COMMIT
 *mangle

--- a/mapserver_hopglass_ffgt/tasks/main.yml
+++ b/mapserver_hopglass_ffgt/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+- name: Create HopGlass directory if not existent
+  file:
+    path: /opt/hopglass/client
+    state: directory
+
+- name: Git for HopGlass
+  git:
+    repo: https://github.com/FreiFunkMuenster/hopglass.git
+    dest: /opt/hopglass/client
+    force: yes
+    version: ffms
+  register: hopglass_git_clone
+
+- name: Create hwpics directory if not exists
+  file:
+    path: /opt/hopglass/hwpics
+    state: directory
+
+- name: Clone meshviewer hwpics repo
+  git:
+    repo: https://github.com/Moorviper/meshviewer_hwpics.git
+    dest: /opt/hopglass/hwpics
+    update: yes
+  register: hopglass_git_clone
+
+- name: Add nodejs repo keys
+  apt_key:
+    id: 1655A0AB68576280
+    url: "https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
+    state: present
+
+- name: Add repo for nodejs
+  apt_repository:
+    repo: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - "deb https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+    - "deb-src https://deb.nodesource.com/node_6.x {{ ansible_distribution_release }} main"
+
+- name: Install nodejs
+  apt:
+    pkg: nodejs
+    state: present
+
+- name: Install dependencies
+  shell: npm install
+  args:
+    chdir: /opt/hopglass/client
+  when: hopglass_git_clone.changed
+
+- name: Install grunt-cli
+  shell: npm install grunt-cli
+  args:
+    chdir: /opt/hopglass/client
+  when: hopglass_git_clone.changed
+
+- name: Build HopGlass
+  shell: node_modules/.bin/grunt
+  args:
+    chdir: /opt/hopglass/client
+  when: hopglass_git_clone.changed
+
+- name: Adjust permissions
+  file:
+    path: /opt/hopglass/client
+    owner: hopglass
+    group: hopglass
+    recurse: yes
+  when: hopglass_git_clone.changed
+
+- name: Create directory
+  file:
+    path: /opt/hopglass/client/build/
+    state: directory
+
+- name: Deploy config.json
+  template:
+    src: config.json.j2
+    dest: /opt/hopglass/client/build/config.json
+    owner: hopglass
+    group: hopglass
+    mode: 0644
+
+- name: Create directory for domainspecific config files
+  file:
+    path: /opt/hopglass/client/build/config/
+    state: directory
+
+- name: Deploy domainspecific config.json files
+  template:
+    src: configdom.json.j2
+    dest: "/opt/hopglass/client/build/config/config_{{item[0]}}.json"
+    owner: hopglass
+    group: hopglass
+    mode: 0644
+  with_items:
+    - "{{domaenen|dictsort}}"
+
+- name: Generate list of all community names
+  set_fact:
+    communities: "{{ domaenen | list | map('extract', domaenen, 'community') | list | unique | sort }}"
+
+- name: Deploy config.json configcommunity
+  template:
+    src: configcommunity.json.j2
+    dest: "/opt/hopglass/client/build/config/config_{{item}}.json"
+    owner: hopglass
+    group: hopglass
+    mode: 0644
+  when: item != "None"
+  with_items:
+    - "{{communities}}"

--- a/mapserver_hopglass_ffgt/templates/config.json.j2
+++ b/mapserver_hopglass_ffgt/templates/config.json.j2
@@ -1,0 +1,77 @@
+{% set proxy_urls = [] %}
+{% for domain in domaenen|dictsort %}
+{% if domain[1].proxy_map_data_url is defined and domain[1].proxy_map_data_url %}
+{% if proxy_urls.append(domain[1].site_code) %}{% endif %}
+{% endif %}
+{% endfor %}
+{
+  "dataPath": [ {% for url in proxy_urls %}"/proxy_{{ url }}/",{% endfor %}"/data/" ],
+  "siteName": "{{freifunk.name}}",
+  "mapSigmaScale": {{ mapconfig.globalMap.map_scale }},
+  "showContact": {{ mapconfig.globalMap.map_show_contact | lower}},
+  "maxAge": {{ mapconfig.globalMap.map_max_age }},
+{% if "max_goto_zoom" in mapconfig.globalMap %}
+  "maxGotoZoom": {{ mapconfig.globalMap.max_goto_zoom }},
+{% endif %}
+  "mapLayers": [
+{% for layer in mapconfig.layers %}
+    {
+      "name": "{{layer.name}}",
+      "url": "{{layer.url}}",
+      "config": {
+{% for k,v in layer.config|dictsort %}
+        "{{k}}": {% if v is number %}{{v}}{% else %}"{{v}}"{% endif %}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+
+      }
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+  "siteNames": [
+{% for domaene in domaenen|dictsort %}
+    { "site": "{{domaene[1].site_code}}", "name": "Mesh {{domaene[0]}} - {{domaene[1].name}}" }{% if not loop.last %},{% endif %}
+{% endfor %}
+  ],
+{% if mapconfig.globalInfos is defined %}
+  "globalInfos": [
+{% for globalInfo in mapconfig.globalInfos %}
+    { "name": "{{ globalInfo.name }}",{% if globalInfo.href is defined %}
+
+      "href": "{{ globalInfo.href }}",{% endif %}{% if globalInfo.iframe is defined %}
+
+      "iframe": "{{ globalInfo.iframe }}"{% endif %}{% if globalInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ globalInfo.thumbnail }}"{% endif %}{% if globalInfo.caption is defined %},
+      "caption": "{{ globalInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+{% if mapconfig.nodeInfos is defined %}
+  "nodeInfos": [
+{% for nodeInfo in mapconfig.nodeInfos %}
+    { "name": "{{ nodeInfo.name }}",{% if nodeInfo.href is defined %}
+
+      "href": "{{ nodeInfo.href }}",{% endif %}{% if nodeInfo.iframe is defined %}
+
+      "iframe": "{{ nodeInfo.iframe }}"{% endif %}{% if nodeInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ nodeInfo.thumbnail }}"{% endif %}{% if nodeInfo.caption is defined %},
+      "caption": "{{ nodeInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+  "hwImg": [
+    {
+      "thumbnail": "/hwpics/{MODELHASH}.svg",
+      "caption": "Knoten {MODELHASH}"
+    }
+  ]
+}

--- a/mapserver_hopglass_ffgt/templates/configcommunity.json.j2
+++ b/mapserver_hopglass_ffgt/templates/configcommunity.json.j2
@@ -1,0 +1,77 @@
+{% set map_domains = [] %}
+{% for domain in domaenen|dictsort %}
+{% if item == domain[1]['community'] %}
+{% if map_domains.append(domain) %}{% endif %}
+{% endif %}
+{% endfor %}
+{
+  "dataPath": [ {% for domain in map_domains %}{% if domaenen[domain[0]].proxy_map_data_url is defined and domaenen[domain[0]].proxy_map_data_url %}"/proxy_{{ domaenen[domain[0]].site_code }}/"{% else %}"/data/map_{{ domain[0] }}/"{% endif %}{% if not loop.last %},{% endif %}{% endfor %} ],
+  "siteName": "Karte {{item}}",
+  "mapSigmaScale": {{ mapconfig.communityMap.map_scale }},
+  "showContact": {{ mapconfig.communityMap.map_show_contact | lower}},
+  "maxAge": {{ mapconfig.communityMap.map_max_age }},
+{% if "max_goto_zoom" in mapconfig.communityMap %}
+  "maxGotoZoom": {{ mapconfig.communityMap.max_goto_zoom }},
+{% endif %}
+  "mapLayers": [
+{% for layer in mapconfig.layers %}
+    {
+      "name": "{{layer.name}}",
+      "url": "{{layer.url}}",
+      "config": {
+{% for k,v in layer.config|dictsort %}
+        "{{k}}": {% if v is number %}{{v}}{% else %}"{{v}}"{% endif %}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+      }
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+  "siteNames": [
+{% for domain in map_domains %}
+    { "site": "{{domain[1].site_code}}", "name": "Mesh {{domain[0]}} - {{domain[1].name}}" }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% if mapconfig.globalInfos is defined %}
+  "globalInfos": [
+{% for globalInfo in mapconfig.globalInfos %}
+    { "name": "{{ globalInfo.name }}",{% if globalInfo.href is defined %}
+
+      "href": "{{ globalInfo.href }}",{% endif %}{% if globalInfo.iframe is defined %}
+
+      "iframe": "{{ globalInfo.iframe }}"{% endif %}{% if globalInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ globalInfo.thumbnail }}"{% endif %}{% if globalInfo.caption is defined %},
+      "caption": "{{ globalInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+{% if mapconfig.nodeInfos is defined %}
+  "nodeInfos": [
+{% for nodeInfo in mapconfig.nodeInfos %}
+    { "name": "{{ nodeInfo.name }}",{% if nodeInfo.href is defined %}
+
+      "href": "{{ nodeInfo.href }}",{% endif %}{% if nodeInfo.iframe is defined %}
+
+      "iframe": "{{ nodeInfo.iframe }}"{% endif %}{% if nodeInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ nodeInfo.thumbnail }}"{% endif %}{% if nodeInfo.caption is defined %},
+      "caption": "{{ nodeInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+  "hwImg": [
+    {
+      "thumbnail": "/hwpics/{MODELHASH}.svg",
+      "caption": "Knoten {MODELHASH}"
+    }
+  ]
+}

--- a/mapserver_hopglass_ffgt/templates/configdom.json.j2
+++ b/mapserver_hopglass_ffgt/templates/configdom.json.j2
@@ -1,0 +1,72 @@
+{
+{% if item[1].proxy_map_data_url is defined and item[1].proxy_map_data_url %}
+  "dataPath": "/proxy_{{item[1].site_code}}/",
+{% else %}
+  "dataPath": "/data/map_{{item[0]}}/",
+{% endif %}
+  "siteName": "{% if item[1].community is defined %}Karte {{item[1].community}}{% else %}{{freifunk.name}}{% endif %} - Mesh {{item[1].name}}",
+  "mapSigmaScale": {{item[1].map_scale}},
+  "showContact": {{item[1].map_show_contact | lower}},
+  "maxAge": {{item[1].map_max_age}},
+{% if "max_goto_zoom" in mapconfig.communityMap %}
+  "maxGotoZoom": {{ mapconfig.communityMap.max_goto_zoom }},
+{% endif %}
+  "mapLayers": [
+{% for layer in mapconfig.layers %}
+    {
+      "name": "{{layer.name}}",
+      "url": "{{layer.url}}",
+      "config": {
+{% for k,v in layer.config|dictsort %}
+        "{{k}}": {% if v is number %}{{v}}{% else %}"{{v}}"{% endif %}{% if not loop.last %},{% endif %}
+
+{% endfor %}
+      }
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+  "siteNames": [
+    { "site": "{{item[1].site_code}}", "name": "Mesh {{item[0]}} - {{item[1].name}}" }
+  ],
+{% if mapconfig.globalInfos is defined %}
+  "globalInfos": [
+{% for globalInfo in mapconfig.globalInfos %}
+    { "name": "{{ globalInfo.name }}",{% if globalInfo.href is defined %}
+
+      "href": "{{ globalInfo.href }}",{% endif %}{% if globalInfo.iframe is defined %}
+
+      "iframe": "{{ globalInfo.iframe }}"{% endif %}{% if globalInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ globalInfo.thumbnail }}"{% endif %}{% if globalInfo.caption is defined %},
+      "caption": "{{ globalInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+{% if mapconfig.nodeInfos is defined %}
+  "nodeInfos": [
+{% for nodeInfo in mapconfig.nodeInfos %}
+    { "name": "{{ nodeInfo.name }}",{% if nodeInfo.href is defined %}
+
+      "href": "{{ nodeInfo.href }}",{% endif %}{% if nodeInfo.iframe is defined %}
+
+      "iframe": "{{ nodeInfo.iframe }}"{% endif %}{% if nodeInfo.thumbnail is defined %}
+
+      "thumbnail": "{{ nodeInfo.thumbnail }}"{% endif %}{% if nodeInfo.caption is defined %},
+      "caption": "{{ nodeInfo.caption }}"{% endif %}
+
+    }{% if not loop.last %},{% endif %}
+
+{% endfor %}
+  ],
+{% endif %}
+  "hwImg": [
+    {
+      "thumbnail": "/hwpics/{MODELHASH}.svg",
+      "caption": "Knoten {MODELHASH}"
+    }
+  ]
+}

--- a/mapserver_nginx_ffgt/handlers/main.yml
+++ b/mapserver_nginx_ffgt/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart nginx
+  service: name=nginx state=restarted

--- a/mapserver_nginx_ffgt/tasks/main.yml
+++ b/mapserver_nginx_ffgt/tasks/main.yml
@@ -1,0 +1,141 @@
+- name: install nginx
+  apt:
+    pkg: ['nginx']
+    update_cache: no
+    state: latest
+
+- name: create letsencrypt directory
+  file: name=/var/www/letsencrypt state=directory
+
+- name: Install default nginx site for letsencrypt requests and https rewrite
+  template:
+    src: templates/default.j2
+    dest: /etc/nginx/sites-available/default
+  register: gendefconf
+
+- name: Activate default nginx site
+  file: src=/etc/nginx/sites-available/default dest=/etc/nginx/sites-enabled/default state=link
+  register: actdefconf
+
+- name: Reload nginx to activate letsencrypt site
+  service: name=nginx state=restarted
+  when: gendefconf.changed or actdefconf.changed
+
+- name: acme install
+  shell: wget -O -  https://get.acme.sh | sh
+  args:
+    creates: /root/.acme.sh/acme.sh
+
+- name: Create certificate
+  shell: /root/.acme.sh/acme.sh --issue -d {{inventory_hostname_short}}.{{freifunk.domain}} -w /var/www/letsencrypt
+  args:
+    creates: /root/.acme.sh/{{inventory_hostname_short}}.{{freifunk.domain}}/ca.cer
+
+- name: install cert to Nginx
+  shell: /root/.acme.sh/acme.sh --installcert -d {{inventory_hostname_short}}.{{freifunk.domain}} --keypath "/etc/ssl/key.pem" --fullchainpath "/etc/ssl/fullchain.pem" --reloadcmd "systemctl restart nginx"
+  args:
+    creates: /etc/ssl/certs/key.pem
+  
+- name: Generate dhparams
+  shell: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+  args:
+    creates: /etc/ssl/certs/dhparam.pem
+
+- name: Create nginx caching dir
+  file:
+    path: /opt/hopglass_nginx_cache
+    state: directory
+
+- name: Create nginx caching dirs for tiles caching
+  file:
+    path: "{{item.path}}"
+    state: directory
+  with_items:
+    - "{{nginx_tiles_cache.cache_locations}}"
+  when: nginx_tiles_cache is defined and "cache_locations" in nginx_tiles_cache
+
+- name: Define cache in nginx.conf
+  lineinfile:
+    regexp: "^[\t ]*proxy_cache_path.*hopglass"
+    line: "\tproxy_cache_path /opt/hopglass_nginx_cache levels=1:2 keys_zone=hopglass:10m inactive=1h max_size=1g;"
+    insertafter: "^[\t ]*http[\t ]*\\{"
+    dest: /etc/nginx/nginx.conf
+  notify:
+    - restart nginx
+
+- name: Define include for tiles cache in nginx.conf
+  lineinfile:
+    regexp: "^[\t ]*include /etc/nginx/tiles_cache.conf;"
+    line: "\tinclude /etc/nginx/tiles_cache.conf;"
+    insertafter: "^[\t ]*http[\t ]*\\{"
+    dest: /etc/nginx/nginx.conf
+  notify:
+    - restart nginx
+  when: nginx_tiles_cache is defined
+
+- name: Deploy tiles_cache.conf
+  template:
+    src: tiles_cache.conf.j2
+    dest: /etc/nginx/tiles_cache.conf
+  notify:
+    - restart nginx
+  when: nginx_tiles_cache is defined
+
+- name: Deploy default ssl nginx site
+  template:
+    src: default_ssl.j2
+    dest: /etc/nginx/sites-available/default_ssl
+  notify:
+    - restart nginx
+
+- name: Aktivate default ssl nginx site
+  file: src=/etc/nginx/sites-available/default_ssl dest=/etc/nginx/sites-enabled/default_ssl state=link
+  register: actsslconf
+
+- name: Reload nginx to activate letsencrypt site
+  service: name=nginx state=restarted
+  when: actsslconf.changed
+
+- name: Clone bootstrap and css files
+  git: repo=https://github.com/FreiFunkMuenster/nodesmap-page.git dest=/opt/nodesmappage force=yes
+
+- name: link css
+  file:
+    src: /opt/nodesmappage/css
+    dest: /var/www/html/css
+    state: link
+
+- name: link js
+  file:
+    src: /opt/nodesmappage/js
+    dest: /var/www/html/js
+    state: link
+
+- name: link fonts
+  file:
+    src: /opt/nodesmappage/fonts
+    dest: /var/www/html/fonts
+    state: link
+
+- name: link icons
+  file:
+    src: /opt/nodesmappage/icons
+    dest: /var/www/html/icons
+    state: link
+
+- name: Generate index.html
+  template:
+    src: index.html.j2
+    dest: /var/www/html/index.html
+
+- name: link hopglass
+  file:
+    src: /opt/hopglass/client/build
+    dest: /var/www/html/map
+    state: link
+
+- name: link hwpics
+  file:
+    src: /opt/hopglass/hwpics/nodes
+    dest: /var/www/html/hwpics
+    state: link

--- a/mapserver_nginx_ffgt/templates/default.j2
+++ b/mapserver_nginx_ffgt/templates/default.j2
@@ -1,0 +1,21 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name {{inventory_hostname_short}}.{{freifunk.domain}};
+
+    location /.well-known/acme-challenge {
+        root /var/www/letsencrypt;
+        try_files $uri $uri/ =404;
+    }
+
+    location /nginx_status {
+        stub_status on;
+        access_log off;
+        allow 127.0.0.1;
+        deny all;
+    }
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}

--- a/mapserver_nginx_ffgt/templates/default_ssl.j2
+++ b/mapserver_nginx_ffgt/templates/default_ssl.j2
@@ -1,0 +1,125 @@
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name {{inventory_hostname_short}}.{{freifunk.domain}};
+
+    ssl_certificate /etc/ssl/fullchain.pem;
+    ssl_certificate_key /etc/ssl/key.pem;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+    ssl_ecdh_curve secp384r1;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    resolver 8.8.8.8 8.8.4.4 valid=300s;
+    resolver_timeout 5s;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubdomains";
+    add_header X-Content-Type-Options nosniff;
+
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+    root /var/www/html;
+
+    location / {
+
+        # redirect into directory to get correct docroot
+        rewrite "^/map([0-9]{2})$" /map$1/ permanent;
+        rewrite "^/map_([^/]+)$" /map$1/ permanent;
+
+        # rewrite config.json to special path
+        rewrite "^/map([0-9]{2})/config.json$" /map/config/config_$1.json break;
+        rewrite "^/map_([^/]+)/config.json$" /map/config/config_$1.json break;
+
+        # rewrite all other
+        rewrite "^/map[0-9]{2}/(.*)$" /map/$1 break;
+        rewrite "^/map_[^/]+/(.*)$" /map/$1 break;
+
+        # First attempt to serve request as file, then
+        # as directory, then fall back to displaying a 404.
+        try_files $uri $uri/ =404;
+
+        # enable gzip compression
+        gzip                    on;
+        gzip_http_version       1.0;
+        gzip_vary               on;
+        gzip_comp_level         2;
+        gzip_proxied            any;
+        gzip_types              text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+    }
+
+    # Proxy for external map data (if any)
+{% for domaene in domaenen|dictsort %}
+{% if domaene[1].proxy_map_data_url is defined and domaene[1].proxy_map_data_url %}
+    location /proxy_{{domaene[1].site_code}}/ {
+        #proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+
+        proxy_pass              {{ domaene[1].proxy_map_data_url }};
+        proxy_redirect          off;
+
+        proxy_cache             hopglass;
+        proxy_cache_valid       2m;
+
+        # enable gzip compression
+        gzip                    on;
+        gzip_http_version       1.0;
+        gzip_vary               on;
+        gzip_comp_level         4;
+        gzip_proxied            any;
+        gzip_types              text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+    }
+{% endif %}
+{% endfor %}
+
+    # Proxy for mapdata
+    location /data/ {
+        # mapdata for each domain, because hopglass can't handle args in uri
+{% for domaene in domaenen|dictsort %}
+        rewrite "^/data/map_{{domaene[0]}}/(.+)$" /$1?filter=site&value={{domaenen[domaene[0]].site_code}} break;
+{% endfor %}
+        #rewrite "^/data/map_([^/]+)/(.+)$" /$2?filter=site&value=$1 break;
+
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+
+        proxy_pass              http://127.0.0.1:4000/;
+        proxy_redirect          off;
+
+        proxy_cache             hopglass;
+        proxy_cache_valid       2m;
+
+        # enable gzip compression
+        gzip                    on;
+        gzip_http_version       1.0;
+        gzip_vary               on;
+        gzip_comp_level         4;
+        gzip_proxied            any;
+        gzip_types              text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+    }
+
+{% if nginx_tiles_cache is defined and 'instances' in nginx_tiles_cache %}
+{% for instance in nginx_tiles_cache.instances %}
+    # tiles cache for {{instance.name}}
+    location {{instance.location}} {
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+
+        proxy_pass              {{instance.dest_url}};
+        proxy_redirect          off;
+
+        proxy_cache             {{instance.cache_location_name}};
+        proxy_cache_valid       {{instance.valid_time}};
+    }
+{% endfor %}
+{% endif %}
+}

--- a/mapserver_nginx_ffgt/templates/index.html.j2
+++ b/mapserver_nginx_ffgt/templates/index.html.j2
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en"><!-- Mit Ansible erzeugt - änderungen werden überschrieben -->
+<head>
+  <title>{{freifunk.name}} - Karten</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png?v=2">
+  <link rel="icon" type="image/png" href="/icons/favicon-32x32.png?v=2" sizes="32x32">
+  <link rel="icon" type="image/png" href="/icons/favicon-16x16.png?v=2" sizes="16x16">
+  <link rel="manifest" href="/icons/manifest.json?v=2">
+  <link rel="mask-icon" href="/icons/safari-pinned-tab.svg?v=2" color="#ffb400">
+  <link rel="shortcut icon" href="/icons/favicon.ico?v=2">
+  <meta name="apple-mobile-web-app-title" content="Freifunk">
+  <meta name="application-name" content="Freifunk">
+  <meta name="msapplication-config" content="/icons/browserconfig.xml?v=2">
+  <meta name="theme-color" content="#dc0067">
+  <link rel="stylesheet" href="css/bootstrap.min.css">
+  <link rel="stylesheet" href="css/ffms.css">
+</head>
+<body>
+	<div class="container">
+	  <div class="page-header">
+    <div class="row">
+      <div class="col-md-2 col-sm-3">
+        <img id="{{freifunk.kurzname}}-logo" src="logo.svg" class="img" alt="Logo {{freifunk.name}}">
+      </div>
+      <div class="col-md-10 col-sm-9">
+        <h2>Karten - {{freifunk.name}}
+    <br/><small>Karten der einzelnen Meshes und der Communities</small></h2>
+      </div>
+    </div>
+    </div>
+  </div>
+  <div class="container">
+  <div class="row">
+    <!-- Suchfeld und Links -->
+    <div class="col-md-4 col-sm-4 col-xs-12">
+        <form type="text" action="javascript:myScroll()"> 
+        <div class="input-group">
+          <!-- USE TWITTER TYPEAHEAD JSON WITH API TO SEARCH -->
+          <input class="form-control" id="system-search" 
+                name="q" placeholder="Suche nach" autofocus>
+            <span class="input-group-btn">
+                <button type="submit" id="searchbutton" class="btn btn-ffms">                
+                    <i class="glyphicon glyphicon-search"></i>
+                </button>
+            </span>
+          </input>
+        </div>
+        </form>
+      <br/>
+      <h4><strong><a href="map/">Gesamtkarte {{freifunk.name}}</a></strong></h4>
+      <p><a class="btn-ffms-collapse visible-xs" data-toggle="collapse" data-target="#narrow-results">&#187; Mehr Freifunk Links</a></p>
+      <div id="narrow-results" class="narrow-results collapse">
+{% if indexconfig.links is defined %}
+{% for link in indexconfig.links %}
+      <p><a href="{{link.link}}">{{link.name}}</a></p>
+{% endfor %}
+{% endif %}
+      </div>
+    </div>
+    <!-- Spalte mit Domänen -->
+    <div class="col-md-4 col-sm-4 col-xs-6">
+        <div class="ffms-align-center">
+        <table  class="table table-list-search table-hover">
+          <thead>
+            <tr>
+              <th>
+                  <div style=text-align:center><h4>Meshes</h4></div>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- Alle Domänen einfügen -->
+{% for domaene in domaenen|dictsort %}
+            <tr>
+              <td>
+                  <a href="map{{domaene[0]}}/">{{domaene[0]}} - {{domaene[1].name}}</a> 
+                  &ensp;
+{% if indexconfig.linktofwdownloader is defined %}
+                  <span class="small">
+                      <a class="ffms-muted" href="{{indexconfig.linktofwdownloader}}{{domaene[0]}}">Firmware </a>
+                  </span>
+{% endif %}
+              </td>
+            </tr>
+{% endfor %}
+          </tbody>
+        </table>
+        </div>
+    </div>
+    <!-- Spalte mit Gruppen -->
+{% set communities = domaenen | list | map('extract', domaenen, 'community') | list | unique | sort %}
+    <div class="col-md-4 col-sm-4 col-xs-6">
+        <div class="ffms-align-center">
+        <table class="table  table-list-search table-hover">
+          <thead>
+            <tr>
+              <th><div style=text-align:center><h4>Gruppen</h4></div></th>
+            </tr>
+          </thead>
+          <tbody>
+            <!-- Alle Communities einfügen -->
+{% for community in communities %}
+{% if community != "None" %}
+            <tr>
+                <td><a Community href="map_{{community}}/">Community {{community}}</a><br/> <span class="ffms-muted">Meshes:</span>  
+{% for domaene in domaenen|dictsort %}
+{% if community == domaene[1].community %}
+                    <a href="map{{domaene[0]}}/">{{domaene[0]}}</a>
+{% endif %}
+{% endfor %}
+                </td>
+            </tr>
+ 
+{% endif %}
+{% endfor %}
+          </tbody>
+        </table>
+        </div>
+    </div>
+  </div>
+  </div>
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <!-- optional via CDN: <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"  </script> -->
+    <script src="js/bootstrap.min.js"></script> 
+    <script src="js/search.js"></script>
+    <script>
+        function myScroll(my) {
+        $('html, body').animate({
+            scrollTop: $(".table").offset().top
+            }, 200);
+        }
+    </script>
+</body>

--- a/mapserver_nginx_ffgt/templates/tiles_cache.conf.j2
+++ b/mapserver_nginx_ffgt/templates/tiles_cache.conf.j2
@@ -1,0 +1,15 @@
+{% if 'cache_locations' in nginx_tiles_cache %}
+{% for cache in nginx_tiles_cache.cache_locations %}
+    proxy_cache_path  {{cache.path}} levels=1:2 keys_zone={{cache.name}}:10m max_size={{cache.max_size}} inactive=365d;
+#   proxy_temp_path   {{cache.path}}/tmp;
+{% endfor %}
+{% endif %}
+{% if 'upstreams' in nginx_tiles_cache %}
+{% for upstream in nginx_tiles_cache.upstreams %}
+    upstream {{upstream.name}} {
+{% for server in upstream.servers %}
+        server {{server}};
+{% endfor %}
+    }
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Ein paar Erweiterungen der Rollen:

- BREAKING CHANGE: über ipv6backbone64prefixstr *muß* nun der interne v6-Präfix für Tunnel gesetzt werden — 2a03:2260:115:ffa1:: sollte nur FFMS nutzen.
- BREAKING CHANGE: Port 25 wird vom Mesh gen Internet blockiert.
- BREAKING CHANGE: Um 'zone "{{freifunk.kurzname}}."' weiterhin konfiguriert zu bekommen, muß "have_local_kurzname_zone" gesetzt werden. (Wir nutzen 4830.org als freifunk.kurzname, und damit erzeugt die Rolle eine falsche Version der öffentlichen Domain. Zudem tun "private" TLDs in aktuellen, insbesondere mobilen, Browsern eher so mäßig — mit DoH wird's auch haarig.)
-  ospf_nat_ip kann analog ff*_nat_ip verwendet werden, um diese IP im internen Routing per OSPF bekannt zu machen.
-  gateways_l2tp_slovenija nutzt letzten python2-kompatiblem commit vor der Änderung auf python3-only.
- Es gibt eine "FFGT-Version" des Mapservers, welche statt numerische Domains zu erzwingen mit normalen Textbezeichnern umgehen kann, ferner können dem Hopglass auch externe Quelle zugeführt werden.
- Bei ipv6_direkt_ausleiten wird ein zusätzlicher OSPF-Prozeß gestartet, der die lokalen Netze dem internen Routing bekannt macht, sodaß auch der Rückweg klappt.
- Kleinere Fixes.