### PR TITLE
fastd: NRPE-Check-Kommando hinzugefügt

### DIFF
--- a/gateways_fastd/tasks/main.yml
+++ b/gateways_fastd/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: Get all enabled fastd instances
   shell: |
     set -o pipefail
-    /bin/ls /etc/systemd/system/multi-user.target.wants/fastd@* | grep -oE "[0-9]+"
+    /bin/ls -1 /etc/systemd/system/multi-user.target.wants/fastd@* | sed -n 's/fastd@\([0-9][0-9]*\)\.service/\1/p'
   args:
     executable: bash
   changed_when: False

--- a/nrpe/files/check_fastd
+++ b/nrpe/files/check_fastd
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+PLUGINDIR=$(dirname $0)
+. $PLUGINDIR/utils.sh
+
+if [ -e /lib/systemd/system/fastd@.service ] ; then
+        domains=$(/bin/ls /etc/systemd/system/multi-user.target.wants/fastd@* | grep -oE "[0-9]+")
+fi
+
+
+if [ -e /etc/systemd/system/fastd.service ] ; then
+        systemctl --quiet is-active fastd.service
+        if [ $? -ne 0 ]; then
+                echo "ERROR: service fastd is not running"
+                exit $STATE_CRITICAL
+        else
+                echo "OK: service fastd is running"
+                exit $STATE_OK
+        fi
+fi
+
+ERROR_IN_DOM=''
+if [ -e /lib/systemd/system/fastd@.service ] ; then
+        for domain in $domains ; do
+                systemctl --quiet is-active fastd@${domain}.service
+                if [ $? -ne 0 ] ; then
+                        ERROR_IN_DOM="$ERROR_IN_DOM $domain"
+                fi
+        done
+
+        if  [[ $ERROR_IN_DOM == '' ]] ; then
+                echo "OK: service fastd is running"
+                exit $STATE_OK
+        else
+                echo "ERROR: service fastd is not running in Dom: $ERROR_IN_DOM"
+                exit $STATE_CRITICAL
+        fi
+fi

--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -45,6 +45,9 @@
 - name: Install check_systemd_service
   copy: "src=check_systemd_service dest='/usr/lib/nagios/plugins/check_systemd_service' owner=root group=root mode=a+x"
 
+- name: Install check_fastd
+  copy: "src=check_fastd dest='/usr/lib/nagios/plugins/check_fastd' owner=root group=root mode=a+x"
+
 - name: Install check_tunneldigger
   copy: "src=check_tunneldigger dest='/usr/lib/nagios/plugins/check_tunneldigger' owner=root group=root mode=a+x"
 

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -32,6 +32,7 @@ command[check_collectd]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C colle
 command[check_pyrespondd]=/usr/lib/nagios/plugins/check_systemd_service py-respondd
 command[check_respondd]=/usr/lib/nagios/plugins/check_systemd_service respondd
 command[check_tunneldigger]=/usr/lib/nagios/plugins/check_tunneldigger
+command[check_fastd]=/usr/lib/nagios/plugins/check_fastd
 command[check_dhcp-server]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C kea-dhcp4
 command[check_isc-dhcp-server]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C dhcpd
 command[check_isc-dhcp-server-leases]=/usr/bin/dhcpd-pools -c /etc/dhcp/dhcpd.conf -l /var/lib/dhcp/dhcpd.leases --warning=80 --critical=90 --perfdata


### PR DESCRIPTION
NRPE-Checkskript & -Kommando für fastd hinzugefügt.
Es wird, wie bei check_tunneldigger, geprüft, ob die fastd-Services aller Domänen laufen. Im Wesentlichen ist es das selbe Skript.

Außerdem habe ich die Erkennung relevanter fastd-Instanzen beim Ausrollen durch Ansible etwas strikter gemacht. Vorher wurden auch fastd-Instanzen, die definitiv nichts mit Domänen zu tun haben, weggeräumt.