### PR TITLE
Borg-Backup-Erweiterungen

### DIFF
--- a/borg_backup_config/tasks/main.yml
+++ b/borg_backup_config/tasks/main.yml
@@ -1,31 +1,59 @@
-- name: Crate repokey on remotehost
-  shell: 'date +%s | sha256sum | base64 | head -c 32 > /root/backup-{{ item.name }}.repokey'
+# Store Repokey on remote host
+## If required repokey is not in inventory:  Create one on remote host and copy it back to the ansible controller
+- name: Generate new repokey on remote host
+  shell: |
+    set -o pipefail
+    date +%s | sha256sum | base64 | head -c 32 > /root/backup-{{ item.name }}.repokey
   args:
-    creates: /root/backup-{{ item.name }}.repokey  
+    executable: bash
+    creates: /root/backup-{{ item.name }}.repokey
   with_items: '{{ borg_backups }}'
+  when: item.backup_server_passphrase is undefined
+
+- name: Copy repokeys from remote host to Ansible controller
+  fetch:
+    src: /root/backup-{{ item.name }}.repokey
+    dest: keyfiles/borg/{{ inventory_hostname }}-{{ item.name }}.repokey
+    flat: yes
+  with_items: '{{ borg_backups }}'
+  when: item.backup_server_passphrase is undefined
+
+## If required repokey is in inventory: Store it on the remote host
+- name: Store repokey from inventory on remote host
+  copy:
+    content: "{{ item.backup_server_passphrase }}"
+    dest: /root/backup-{{ item.name }}.repokey
+  with_items: '{{ borg_backups }}'
+  when: item.backup_server_passphrase is defined
+
+##
 
 - name: Adjust permissions of repokeys
   file:
     path: /root/backup-{{ item.name }}.repokey
     mode: 0600
   with_items: '{{ borg_backups }}'
+  ignore_errors: '{{ ansible_check_mode }}'
 
-- name: Get repokeys from remote host.
-  fetch:
+- name: Get repokeys from remote host
+  slurp:
     src: /root/backup-{{ item.name }}.repokey
-    dest: keyfiles/borg/{{ inventory_hostname }}-{{ item.name }}.repokey
-    flat: yes
+  register: repokey
   with_items: '{{ borg_backups }}'
+  ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Create Repo on Backuptarget
-  shell: borg init --encryption=repokey-blake2 ssh://{{ item.backup_server_user }}@{{ item.backup_server }}:{{ item.backup_server_port }}/./{{ ansible_hostname }}-bkp && touch /root/.repo-{{ item.name }}-created
+  shell: borg init --encryption=repokey-blake2 \
+           ssh://{{ item.item.backup_server_user }}@{{ item.item.backup_server }}:{{ item.item.backup_server_port }}/./{{ item.item.backup_server_path | default(ansible_hostname + "-bkp") }} \
+           && touch /root/.repo-{{ item.item.name }}-created
   args:
-    creates: /root/.repo-{{ item.name }}-created
+    creates: /root/.repo-{{ item.item.name }}-created
   environment:
-    BORG_PASSPHRASE: "{{ lookup('file', 'keyfiles/borg/' + inventory_hostname + '-' + item.name + '.repokey') }}"
+    BORG_PASSPHRASE: "{{ item['content'] | b64decode }}"
     BORG_DISPLAY_PASSPHRASE: 'no'
-    BORG_RSH: 'ssh -o "StrictHostKeyChecking no" -i /root/.ssh/id_rsa_borg'
-  with_items: '{{ borg_backups }}'
+    BORG_RSH: 'ssh -o "StrictHostKeyChecking no" -o "PasswordAuthentication no" -i /root/.ssh/id_rsa_borg'
+  with_items: '{{ repokey.results }}'
+  ignore_errors: '{{ ansible_check_mode }}'
 
 - name: Create backup scripts
   template: src=backup.j2 dest=/usr/bin/backup-{{ item.name }} mode=0700
@@ -36,8 +64,14 @@
     name: borg backup-{{ item.name }}
     job: /usr/bin/backup-{{ item.name }} >> /var/log/backup-{{ item.name }}.log 2>&1
     day: '*'
-    hour: 4
-    minute: 30
+    hour: '4'
+    minute: '30'
     state: present
     user: root
+  with_items: '{{ borg_backups }}'
+
+- name: Configure logrotate
+  template:
+    src: logrotate-borgbackup.j2
+    dest: /etc/logrotate.d/borgbackup-cron-{{ item.name }}
   with_items: '{{ borg_backups }}'

--- a/borg_backup_config/templates/backup.j2
+++ b/borg_backup_config/templates/backup.j2
@@ -1,5 +1,8 @@
 #!/bin/sh
-REPOSITORY=ssh://{{ item.backup_server_user }}@{{ item.backup_server }}:{{ item.backup_server_port }}/./{{ ansible_hostname }}-bkp
+
+# {{ ansible_managed }}
+
+REPOSITORY=ssh://{{ item.backup_server_user }}@{{ item.backup_server }}:{{ item.backup_server_port }}/./{{ item.backup_server_path | default(ansible_hostname + "-bkp") }}
 export BORG_PASSPHRASE=$(cat /root/backup-{{ item.name }}.repokey)
 export BORG_RSH='ssh -i /root/.ssh/id_rsa_borg'
 
@@ -36,7 +39,7 @@ echo "Dumping all pgsql DBs"
 {% endif %}
 
 echo "Borg create"
-/usr/local/bin/borg create {{ item.borg_options }} \
+borg create {{ item.borg_options }} \
         $REPOSITORY::'{hostname}-{now:%Y-%m-%d-%H-%M-%S}'\
         {{ item.directories | join(' ') }}{% if item.mysqldatabases is defined or item.pgsqldatabases is defined or (item.pgsqldumpall is defined and item.pgsqldumpall) %} \{% endif %}
 {% if item.mysqldatabases is defined %}
@@ -66,7 +69,7 @@ echo "Borg create"
 BORGRESULT=$?
 echo "Borg prune"
 if [ $BORGRESULT -eq 0 ] ; then
-/usr/local/bin/borg prune -v --list $REPOSITORY --prefix '{hostname}-' {{ item.borg_prune }}
+borg prune -v --list $REPOSITORY --prefix '{hostname}-' {{ item.borg_prune }}
 fi
 {% endif %}
 echo "------------------------------------------------------------------STOP-------------------------------------------------------------------"

--- a/borg_backup_config/templates/logrotate-borgbackup.j2
+++ b/borg_backup_config/templates/logrotate-borgbackup.j2
@@ -1,0 +1,7 @@
+/var/log/backup-{{ item.name }}.log {
+    {{logrotate.cycle}}
+    rotate {{logrotate.count}}
+    copytruncate
+    delaycompress
+    compress
+}

--- a/borg_backup_install/tasks/main.yml
+++ b/borg_backup_install/tasks/main.yml
@@ -1,10 +1,21 @@
-- name: Install dependencies
+- name: Install dependencies for building borgbackup
   apt:
-    pkg: ['python3', 'python3-dev', 'python3-pip', 'python-virtualenv', 'libssl-dev', 'openssl', 'libacl1-dev', 'libacl1', 'liblz4-dev', 'liblz4-1', 'build-essential']
+    pkg: ['python3', 'python3-dev', 'python3-pip', 'python-virtualenv', 'libssl-dev', 'openssl',
+         'libacl1-dev', 'libacl1', 'liblz4-dev', 'liblz4-1', 'build-essential']
     state: present
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version == '9')
 
-- name: Install borgbackup
-  pip: 
-    name: ['borgbackup==1.1.0'] 
+- name: Install borgbackup from source
+  pip:
+    name: ['borgbackup==1.1.0']
     state: present
     executable: pip3
+  when: (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') or
+        (ansible_distribution == 'Debian' and ansible_distribution_version == '9')
+
+- name: Install borgbackup from repository
+  apt:
+    pkg: ['borgbackup']
+  when: not (ansible_distribution == 'Ubuntu' and ansible_distribution_version == '16.04') and
+        not (ansible_distribution == 'Debian' and ansible_distribution_version == '9')

--- a/borg_backup_sshkey/tasks/main.yml
+++ b/borg_backup_sshkey/tasks/main.yml
@@ -5,7 +5,7 @@
     ssh_key_bits: 2048
     ssh_key_file: /root/.ssh/id_rsa_borg
 
-- name: Get /root/.ssh/id_rsa_borg.pub from remote host.
+- name: Get /root/.ssh/id_rsa_borg.pub from remote host
   fetch:
     src: /root/.ssh/id_rsa_borg.pub
     dest: keyfiles/borg/{{ inventory_hostname }}.pub

--- a/borg_backup_target/tasks/main.yml
+++ b/borg_backup_target/tasks/main.yml
@@ -14,7 +14,7 @@
     state: present
 
 - name: create home directory if nessesary and audjust permissions
-  file: 
+  file:
     name: "/home/{{ borg_backup_target.config.backup_user }}"
     state: directory
     owner: '{{ borg_backup_target.config.backup_user }}'
@@ -38,14 +38,14 @@
     mode: 0700
 
 - name: deploy authorized keys
-  authorized_key: 
+  authorized_key:
     user: '{{ borg_backup_target.config.backup_user }}'
     key: "{{ lookup('file', 'keyfiles/borg/' + item + '.pub') }}"
     key_options: 'command="cd {{ borg_backup_target.config.path_to_repo_pool }}/{{ item }};borg serve --restrict-to-path {{ borg_backup_target.config.path_to_repo_pool }}/{{ item }}",no-port-forwarding,no-X11-forwarding,no-pty,no-agent-forwarding,no-user-rc'
   with_items: '{{ borg_backup_target.target_for }}'
 
 - name: audjust permissions of authorized_keys
-  file: 
+  file:
     name: "/home/{{ borg_backup_target.config.backup_user }}/.ssh/authorized_keys"
     owner: '{{ borg_backup_target.config.backup_user }}'
     group: '{{ borg_backup_target.config.backup_group }}'

--- a/nrpe/files/check_borg
+++ b/nrpe/files/check_borg
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+#exitcodes
+STATE_OK=0
+STATE_WARNING=1
+STATE_CRITICAL=2
+STATE_UNKNOWN=3
+
+#########################################################################
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <Name> <URL>"
+    exit $STATE_UNKNOWN
+fi
+
+REPOKEY="/root/backup-$1.repokey"
+if [ ! -f "${REPOKEY}" ]; then
+    echo "Passphrase-Datei ${REPOKEY} nicht gefunden"
+    exit $STATE_CRITICAL
+fi
+
+export BORG_PASSPHRASE=$(cat ${REPOKEY})
+export BORG_RSH='ssh -i /root/.ssh/id_rsa_borg'
+REPOSITORY=$2
+
+# return STATE_CRITICAL if last successful backup is older than MAXAGE seconds 
+MAXAGE=$((25*3600))
+
+
+# get date of last successful run
+LASTSUCCESS_DATETIME=$(borg list --last 1 --sort timestamp --format '{time}' ${REPOSITORY})
+
+# return STATE_UNKNOWN if no date of last successful run
+if [ -z "${LASTSUCCESS_DATETIME}" ]; then
+  echo "UNKNOWN: Zeitpunkt des letzten erfolgreichen Backups unbekannt"
+  exit $STATE_UNKNOWN
+fi
+
+# return STATE_CRITICAL if timestamp of last successful run is older than MAXAGE
+LASTSUCCESS_TS=$(date --date="${LASTSUCCESS_DATETIME}" "+%s")
+NOW_TS=$(date "+%s")
+CRITICAL_AGE_TS=$((NOW_TS-3600*MAXAGE))
+
+if [ "${LASTSUCCESS_TS}" -lt "${CRITICAL_AGE_TS}" ]; then
+  echo "CRITICAL: Letztes erfolgreiches Backup war vor $(((NOW_TS-LASTSUCCESS_TS)/3600)) Stunden"
+  exit $STATE_CRITICAL
+fi
+
+# return STATE_OK
+echo "OK: Letztes erfolgreiches Backup war vor $(((NOW_TS-LASTSUCCESS_TS)/3600)) Stunden"
+exit $STATE_OK

--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -80,6 +80,9 @@
 - name: Install check_bird6_sessions
   copy: "src=check_bird6_sessions dest='/usr/lib/nagios/plugins/check_bird6_sessions' owner=root group=root mode=a+x"
 
+- name: Install check_borg
+  copy: "src=check_borg dest='/usr/lib/nagios/plugins/check_borg' owner=root group=root mode=a+x"
+
 - name: Install sudo permissions
   template: "src=sudoers.j2 dest='/etc/sudoers.d/nrpe' owner=root group=root mode=440"
 

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -68,3 +68,11 @@ command[check_batip_{{domaene[0]}}]=/usr/lib/nagios/plugins/check_batip -D {{dom
 #command[check_FFTesterV6_{{domaene[0]}}]=sudo /root/gits/tools/Freifunk-Tester/icinga_reporter.sh {{freifunk.kurzname}}d{{domaene[0]}} IPv6-ping-test-to-google.de random
 # {% endfor %}
 #{% endif %}
+
+{% if borg_backups is defined %}
+## Borg Backups
+{% for repo in borg_backups %}
+command[check_borg-{{ repo.name }}]=sudo /usr/lib/nagios/plugins/check_borg "{{ repo.name }}" "ssh://{{ repo.backup_server_user }}@{{ repo.backup_server }}:{{ repo.backup_server_port }}/./{{ repo.backup_server_path | default(ansible_hostname + "-bkp") }}" 
+{% endfor %}
+{% endif %}
+

--- a/nrpe/templates/sudoers.j2
+++ b/nrpe/templates/sudoers.j2
@@ -1,4 +1,5 @@
 # {{ ansible_managed }}
 nagios ALL=NOPASSWD: /usr/lib/nagios/plugins/check_bird_sessions
 nagios ALL=NOPASSWD: /usr/lib/nagios/plugins/check_bird6_sessions
+nagios ALL=NOPASSWD: /usr/lib/nagios/plugins/check_borg
 # nagios ALL=NOPASSWD: /root/gits/tools/Freifunk-Tester/icinga_reporter.sh


### PR DESCRIPTION
- Zusätzliche, optionale Konfigurationsvariablen:
  - Backup-Repo-Pfad auf dem Borgbackup-Target konfigurierbar machen (Variable "backup_server_path"). Wenn nicht gesetzt wird, wie bisher auch, "/ansible_hostname + "-bkp"" benutzt. Hintergrund: Wir verwenden für das Backup die Hetzner Storage-Box und müssen da ein Unterverzeichnis nutzen.
  - Der Repository-Key kann direkt im Inventory gesetzt werden (Variable "backup_server_passphrase"). Wenn nicht gesetzt  und ein Key fehlt, dann wird dieser, wie bisher auch, auf dem Host erzeugt und auf den Rechner kopiert von dem Ansible aus aufgerufen wird.
- Bei Debian 10 und Ubuntu 18 wird borgbackup 1.1 per apt direkt aus dem Distributions-Repository installiert. Damit das Backup-Skript sowohl mit dem Distributions-Borg als auch mit dem aus pip3 funktioniert mussten im Backup-Skript die absoluten Pfade zu borg entfernt werden.
- Kleinere Ansible-Änderungen:
  - Abbruch im Ansible-check_mode bei noch nicht vorhandenem Repo behoben
  - Hänger beim Ausrollen der Rolle behoben: Wenn der ssh-Key des Backup-Users in authorized_keys auf dem Borgbackup-Target fehlte, blieb Ansible stehen. Jetzt wird abgebrochen.
  - Einige Ansible-lint-Warnungen behoben
- Rotiere Logdatei des Borg-Cronjobs mit Logrotate
- Monitoring der Borg-Backup-Repositories implementiert: Jedes
Borg-Repository bekommt einen eigenen Check (NRPE-Kommando "check_borg-< RepositoryName >"). Borg läuft 1x täglich, daher gibt's den Status "Critical" wenn das letzte erfolgreiche Backup älter als einen Tag ist.