### PR TITLE
Neue Rolle: exim4-daemon-light

### DIFF
--- a/exim4-daemon-light/handlers/main.yml
+++ b/exim4-daemon-light/handlers/main.yml
@@ -1,0 +1,7 @@
+- name: restart exim4
+  service:
+    name: exim4
+    state: restarted
+
+- name: update-exim4.conf
+  command: update-exim4.conf

--- a/exim4-daemon-light/meta/main.yml
+++ b/exim4-daemon-light/meta/main.yml
@@ -1,0 +1,22 @@
+galaxy_info:
+  author: citronalco
+  min_ansible_version: 2.2
+  license: GPLv3
+  platforms:
+    - name: Debian
+      versions:
+      - 10
+  description: |
+    Installiert den Mailserver exim4-daemon-light
+
+    E-Mails werden nur von localhost akzeptiert und dann an den in der Variable "mail" angegebenen SMTP-Server weitergeleitet.
+    Beispiel:
+
+    mail:
+      senderemail: icinga2@example.com
+      smtp: mail.foo.bar
+      user: benutzername
+      pw: geheim
+
+    Als Absenderadresse wird "icinga2@example.com" verwendet.
+    Zur Authentifizierung am SMTP-Server "mail.foo.bar" wird der Benutzername "benutzername" und das Passwort "geheim" benutzt.

--- a/exim4-daemon-light/tasks/main.yml
+++ b/exim4-daemon-light/tasks/main.yml
@@ -1,0 +1,51 @@
+- name: Install exim4-daemon-light
+  apt:
+    pkg: [ 'exim4-daemon-light' ]
+    state: present
+
+- name: Configure exim4
+  template:
+    src: 'update-exim4.conf.conf.j2'
+    dest: '/etc/exim4/update-exim4.conf.conf'
+  notify:
+    - update-exim4.conf
+    - restart exim4
+
+- name: Configure authentication at remote smtp server
+  template:
+    src: 'passwd.client.j2'
+    dest: '/etc/exim4/passwd.client'
+    mode: '0640'
+    group: 'Debian-exim'
+  notify: restart exim4
+
+- name: Set sender email address
+  template:
+    src: 'email-addresses.j2'
+    dest: '/etc/email-addresses'
+  notify: restart exim4
+
+- name: Use sender email address for all users
+  replace:
+    path: "/etc/exim4/exim4.conf.template"
+    regexp: '^(.*\${lookup{\${local_part} })lsearch({ /etc/email-addresses }.*)$'
+    replace: '\1wildlsearch\2'
+  notify: restart exim4
+
+- name: Update logrotate cycle in /etc/logrotate.d/
+  replace:
+    dest: "{{ item }}"
+    regexp: 'daily|weekly|monthly'
+    replace: '{{ logrotate.cycle }}'
+  with_items:
+    - /etc/logrotate.d/exim4-base
+    - /etc/logrotate.d/exim4-paniclog
+
+- name: Update logrotate count in /etc/logrotate.d/
+  replace:
+    dest: "{{ item }}"
+    regexp: 'rotate[ \t]+[0-9]+'
+    replace: 'rotate {{ logrotate.count }}'
+  with_items:
+    - /etc/logrotate.d/exim4-base
+    - /etc/logrotate.d/exim4-paniclog

--- a/exim4-daemon-light/templates/email-addresses.j2
+++ b/exim4-daemon-light/templates/email-addresses.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+*: {{ mail.senderemail }}

--- a/exim4-daemon-light/templates/passwd.client.j2
+++ b/exim4-daemon-light/templates/passwd.client.j2
@@ -1,0 +1,2 @@
+# {{ ansible_managed }}
+{{ mail.smtp }}:{{ mail.user }}:{{ mail.pw }}

--- a/exim4-daemon-light/templates/update-exim4.conf.conf.j2
+++ b/exim4-daemon-light/templates/update-exim4.conf.conf.j2
@@ -1,0 +1,33 @@
+# {{ ansible_managed }}
+
+# /etc/exim4/update-exim4.conf.conf
+#
+# Edit this file and /etc/mailname by hand and execute update-exim4.conf
+# yourself or use 'dpkg-reconfigure exim4-config'
+#
+# Please note that this is _not_ a dpkg-conffile and that automatic changes
+# to this file might happen. The code handling this will honor your local
+# changes, so this is usually fine, but will break local schemes that mess
+# around with multiple versions of the file.
+#
+# update-exim4.conf uses this file to determine variable values to generate
+# exim configuration macros for the configuration file.
+#
+# Most settings found in here do have corresponding questions in the
+# Debconf configuration, but not all of them.
+#
+# This is a Debian specific file
+
+dc_eximconfig_configtype='satellite'
+dc_other_hostnames='{{ inventory_hostname_short }}'
+dc_local_interfaces='127.0.0.1 ; ::1'
+dc_readhost='{{ inventory_hostname_short }}'
+dc_relay_domains=''
+dc_minimaldns='false'
+dc_relay_nets=''
+dc_smarthost='{{ mail.smtp }}'
+CFILEMODE='644'
+dc_use_split_config='false'
+dc_hide_mailname='true'
+dc_mailname_in_oh='true'
+dc_localdelivery='mail_spool'


### PR DESCRIPTION
Ich weiß nicht ob ihr das brauchen könnt, aber für den Fall dass:

Diese Rolle installiert den Mailserver exim4-daemon-light.
E-Mails werden nur von localhost akzeptiert und dann an den in der Variable "mail" angegebenen SMTP-Server weitergeleitet.

Beispielkonfiguration:
```
    mail:
      senderemail: icinga2@example.com
      smtp: mail.foo.bar
      user: benutzername
      pw: geheim
```
Als Absenderadresse wird für alle E-Mails stets "icinga2@example.com" verwendet.
Zur Authentifizierung am SMTP-Server "mail.foo.bar" wird der Benutzername "benutzername" und das Passwort "geheim" benutzt.