### PR TITLE
Neue Rolle: icinga2-server

### DIFF
--- a/icinga2-server/README.md
+++ b/icinga2-server/README.md
@@ -1,0 +1,25 @@
+Diese Rolle installiert Icinga2 und optional IcingaWeb2.
+Es wird die Rolle exim4-daemon-light benötigt.
+
+Die Konfiguration erfolgt durch Variable "icinga2":
+```
+    icinga2:
+      api: true
+      icingaweb2: true
+      userliste:
+        - user: username1
+          pw: passwort1
+          email: username1@foobar.com
+        - user: username2
+          pw: passwort2
+        - email: beispiel@bar.baz
+```
+- **api:** Icinga2-API ein- (=true) oder ausschalten (=false). Standard: false. Über die API ist nur Monitoring erlaubt, kein Anlegen/Ändern/Löschen von Objekten u.ä.
+- **icingaweb2:** IcingaWeb2-Weboberfläche ein- (=true) oder ausschalten (=false). Standard: false
+- **userliste:** Enthält eine Liste mit Benutzern. Ein Benutzer muss Benutzername und Passwort und/oder E-Mailadresse haben.
+
+Falls die Icinga2-API und/oder IcingaWeb2 eingeschaltet ist, dann haben alle in "userliste" mit Benutzername ("user") und Passwort ("pw") angebenen Benutzer darauf Zugriff.
+An alle in "userliste" angegebenen E-Mail-Adressen ("email") versendet Icinga2 Notifications. Dazu ist die Rolle exim4-daemon-light nötig, die die E-Mails lokal annimmt und an einen SMTP-Server weiterleitet.
+
+Im Beispiel oben gibt es drei User: Zwei davon können sich an der API und an IcingaWeb2 anmelden, einer davon bekommt die Alerts zusätzlich per E-Mail. Der dritte User kann sich nirgends anmelden und wird nur per E-Mail über Alerts informiert.
+

--- a/icinga2-server/files/apache2-icingaweb2-local.conf
+++ b/icinga2-server/files/apache2-icingaweb2-local.conf
@@ -1,0 +1,17 @@
+# Ansible managed
+
+RedirectMatch ^/$ /icingaweb2
+
+<Directory "/usr/share/icingaweb2/public">
+    AuthType Basic
+    AuthName "Icingaweb2"
+    AuthUserFile /etc/icingaweb2/.http-users
+
+    <Files *.php>
+        php_value date.timezone "Europe/Berlin"
+    </Files>
+
+    <RequireAny>
+        require valid-user
+    </RequireAny>
+</Directory>

--- a/icinga2-server/files/icingaweb2/authentication.ini
+++ b/icinga2-server/files/icingaweb2/authentication.ini
@@ -1,0 +1,6 @@
+# Ansible managed
+
+[icingaweb2]
+strip_username_regexp = ""
+backend = "external"
+

--- a/icinga2-server/files/icingaweb2/config.ini
+++ b/icinga2-server/files/icingaweb2/config.ini
@@ -1,0 +1,13 @@
+# Ansible managed
+
+[global]
+show_stacktraces = "1"
+show_application_state_messages = "1"
+config_backend = "ini"
+
+[logging]
+log = "syslog"
+level = "ERROR"
+application = "icingaweb2"
+facility = "user"
+

--- a/icinga2-server/files/icingaweb2/modules/graphite/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/graphite/config.ini
@@ -1,0 +1,5 @@
+# Ansible managed
+
+[graphite]
+url = "http://localhost:8180"
+insecure = "0"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/backends.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/backends.ini
@@ -1,0 +1,5 @@
+# Ansible managed
+
+[icinga]
+type = "ido"
+resource = "icinga_ido"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/commandtransports.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/commandtransports.ini
@@ -1,0 +1,5 @@
+# Ansible managed
+
+[icinga2]
+transport = "local"
+path = "/var/run/icinga2/cmd/icinga2.cmd"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/config.ini
@@ -1,0 +1,4 @@
+# Ansible managed
+
+[security]
+protected_customvars = "*pw*,*pass*,community"

--- a/icinga2-server/files/icingaweb2/modules/translation/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/translation/config.ini
@@ -1,0 +1,6 @@
+# Ansible managed
+
+[translation]
+msgmerge = /usr/bin/msgmerge
+xgettext = /usr/bin/xgettext
+msgfmt = /usr/bin/msgfmt

--- a/icinga2-server/handlers/main.yml
+++ b/icinga2-server/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+
+- name: restart icinga2
+  service:
+    name: icinga2
+    state: restarted
+
+- name: reload apache2
+  service:
+    name: apache2
+    state: reloaded

--- a/icinga2-server/meta/main.yml
+++ b/icinga2-server/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: exim4-daemon-light

--- a/icinga2-server/tasks/icinga2-api.yml
+++ b/icinga2-server/tasks/icinga2-api.yml
@@ -1,0 +1,57 @@
+### API-Module
+- name: Configure hostname for certificates
+  lineinfile:
+    dest: /etc/icinga2/constants.conf
+    regexp: '^const NodeName\s*='
+    line: 'const NodeName = "{{ ansible_hostname }}"'
+  notify: restart icinga2
+
+- name: Create Icinga2 API CA directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: nagios
+    group: nagios
+    mode: "0700"
+  with_items:
+    - '/var/lib/icinga2/ca'
+    - '/var/lib/icinga2/certs'
+
+- name: Create Icinga2 API CA
+  command:
+    cmd: icinga2 pki new-ca
+    creates: '{{ item.creates }}'
+  loop:
+    - creates: '/var/lib/icinga2/ca/ca.key'
+    - creates: '/var/lib/icinga2/ca/ca.crt'
+  notify: restart icinga2
+
+- name: Generate CSR
+  command:
+    cmd: icinga2 pki new-cert \
+      --cn {{ ansible_hostname }} --key /var/lib/icinga2/certs/{{ ansible_hostname }}.key --csr /var/lib/icinga2/certs/{{ ansible_hostname }}.csr
+    creates: '{{ item.creates }}'
+  loop:
+    - creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.key'
+    - creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.csr'
+  notify: restart icinga2
+
+- name: Sign CSR and create certifiate
+  command:
+    cmd: icinga2 pki sign-csr --csr /var/lib/icinga2/certs/{{ ansible_hostname }}.csr --cert /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
+    creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.crt'
+  notify: restart icinga2
+
+- name: Copy CA certificate
+  copy:
+    remote_src: yes
+    src: '/var/lib/icinga2/ca/ca.crt'
+    dest: '/var/lib/icinga2/certs/ca.crt'
+  notify: restart icinga2
+
+- name: Enable Icinga2 API module
+  file:
+    src: '../features-available/api.conf'
+    dest: '/etc/icinga2/features-enabled/api.conf'
+    state: link
+  notify: restart icinga2

--- a/icinga2-server/tasks/icinga2.yml
+++ b/icinga2-server/tasks/icinga2.yml
@@ -1,0 +1,95 @@
+### Ansible Prerequisites
+- name: Install python3-pymysql (required by Ansible)
+  apt:
+    pkg: [ 'python3-pymysql']
+
+### Icinga2
+- name: Install Icinga2
+  apt:
+    pkg: [ 'icingacli', 'icinga2', 'monitoring-plugins-basic', 'nagios-nrpe-plugin' ]
+    state: present
+
+### Command-Module
+- name: Enable Icinga2 command module
+  file:
+    src: '../features-available/command.conf'
+    dest: '/etc/icinga2/features-enabled/command.conf'
+    state: link
+  notify: restart icinga2
+
+### IDO-Module
+- name: Install MariaDB and Icinga2 IDO modules
+  apt:
+    pkg: [ 'mariadb-server', 'icinga2-ido-mysql' ]
+    state: present
+
+- name: Check state of Icinga2 IDO configuration
+  stat:
+    path: '/etc/icinga2/features-enabled/ido-mysql.conf'
+  register: icinga2_ido_db_conf
+
+- name: Configure Icinga2 IDO feature with random mysql password
+  template:
+    src: 'icinga2/features/ido/ido-mysql.conf.j2'
+    dest: '/etc/icinga2/features-enabled/ido-mysql.conf'
+    owner: 'nagios'
+    group: 'nagios'
+    mode: '0600'
+  when: not icinga2_ido_db_conf.stat.exists
+  notify: restart icinga2
+
+- name: Read ido-mysql.conf
+  slurp:
+    src: '/etc/icinga2/features-enabled/ido-mysql.conf'
+  register: icinga2_ido_db_conf_file
+
+- name: Extract Icinga2 IDO database password from ido-mysql.conf
+  set_fact:
+    icinga2_ido_db_pw: "{{ icinga2_ido_db_conf_file['content'] | b64decode | regex_findall('password = \"(.+)\"') | first }}"
+
+- name: Create IDO database
+  mysql_db:
+    login_unix_socket: '/run/mysqld/mysqld.sock'
+    name: 'icinga2_ido'
+  register: icinga2_ido_db
+
+- name: Create IDO database user
+  mysql_user:
+    login_unix_socket: '/run/mysqld/mysqld.sock'
+    name: 'icinga2_ido'
+    password: '{{ icinga2_ido_db_pw }}'
+    host: localhost
+    priv: 'icinga2_ido.*:ALL'
+
+- name: Import IDO database schema
+  mysql_db:
+    login_unix_socket: '/run/mysqld/mysqld.sock'
+    name: 'icinga2_ido'
+    state: import
+    target: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
+  when: icinga2_ido_db.changed
+  notify: restart icinga2
+  tags: skip_ansible_lint
+
+### Config Files
+- name: Clean default config files
+  file:
+    state: absent
+    path: "/etc/icinga2/conf.d/{{ item }}"
+  with_items:
+    - "apt.conf"
+    - "downtimes.conf"
+    - "groups.conf"
+    - "hosts.conf"
+    - "services.conf"
+  notify: reload icinga2
+
+- name: Create base configuration
+  template:
+    src: "{{ item.src }}"
+    dest: "/etc/icinga2/conf.d/{{ item.path|regex_replace('.j2','') }}"
+  with_filetree: "templates/icinga2/conf.d/"
+  when: item.state == "file"
+  notify: reload icinga2
+  tags:
+    - skip_ansible_lint

--- a/icinga2-server/tasks/icingaweb2.yml
+++ b/icinga2-server/tasks/icingaweb2.yml
@@ -1,0 +1,111 @@
+### Ansible Prerequisites
+- name: Install python3-passlib (required by Ansible)
+  apt:
+    pkg: [ 'python3-passlib' ]
+
+- name: Install IcingaWeb2
+  apt:
+    pkg: [ 'icingaweb2', 'apache2' ]
+    state: present
+
+### IDO
+- name: Read ido-mysql.conf
+  slurp:
+    src: '/etc/icinga2/features-enabled/ido-mysql.conf'
+  register: icinga2_ido_db_conf_file
+
+- name: Extract icinga2 ido database password from ido-mysql.conf
+  set_fact:
+    icinga2_ido_db_pw: "{{ icinga2_ido_db_conf_file['content'] | b64decode | regex_findall('password = \"(.+)\"') | first }}"
+
+- name: Configure connection to IDO database
+  template:
+    src: 'icingaweb2/resources.ini.j2'
+    dest: '/etc/icingaweb2/resources.ini'
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '0640'
+
+### Monitoring Module
+- name: Install IcingaWeb2 monitoring module
+  apt:
+    pkg: [ 'icingaweb2-module-monitoring' ]
+    state: present
+
+- name: Create enabledModules directory
+  file:
+    path: '/etc/icingaweb2/enabledModules'
+    state: directory
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '2750'
+
+- name: Enable IcingaWeb2 monitoring module
+  file:
+    src: '/usr/share/icingaweb2/modules/monitoring'
+    dest: '/etc/icingaweb2/enabledModules/monitoring'
+    state: link
+
+- name: Configure IcingaWeb2 monitoring module
+  copy:
+    src: 'icingaweb2/modules/monitoring/'
+    dest: '/etc/icingaweb2/modules/monitoring'
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '0660'
+    directory_mode: '2770'
+
+### Enable IcingaWeb2 in Apache
+- name: Enable IcingaWeb2 in Apache
+  file:
+    src: '/etc/apache2/conf-available/icingaweb2.conf'
+    dest: '/etc/apache2/conf-enabled/icingaweb2.conf'
+    state: link
+  notify: reload apache2
+
+### Authentication
+- name: Configure basic authentication in Apache
+  copy:
+    src: 'apache2-icingaweb2-local.conf'
+    dest: '/etc/apache2/conf-enabled/icingaweb2-local.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: reload apache2
+
+- name: Create htpasswd file
+  htpasswd:
+    path: '/etc/icingaweb2/.http-users'
+    name: '{{ item.user }}'
+    password: '{{ item.pw }}'
+    owner: 'root'
+    group: 'www-data'
+    mode: '0640'
+  with_items: "{{ icinga2.userliste }}"
+  when: item.user is defined and item.pw is defined
+
+- name: Configure IcingaWeb2 to use Apache authentication provider
+  copy:
+    src: 'icingaweb2/authentication.ini'
+    dest: '/etc/icingaweb2/authentication.ini'
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '0640'
+
+### Logging
+- name: Configure logging
+  copy:
+    src: 'icingaweb2/config.ini'
+    dest: '/etc/icingaweb2/config.ini'
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '0640'
+
+### Users
+- name: Configure user roles
+  template:
+    src: 'icingaweb2/roles.ini.j2'
+    dest: '/etc/icingaweb2/roles.ini'
+    owner: 'www-data'
+    group: 'icingaweb2'
+    mode: '0640'

--- a/icinga2-server/tasks/main.yml
+++ b/icinga2-server/tasks/main.yml
@@ -1,0 +1,34 @@
+- import_tasks: icinga2.yml
+  tags:
+    - 'role::icinga2'
+
+- import_tasks: icinga2-api.yml
+  when: icinga2.api is defined and icinga2.api
+  tags:
+    - 'role::icinga2-api'
+
+- name: Disable Icinga2 API module
+  when: icinga2.api is undefined or not icinga2.api
+  file:
+    path: '/etc/icinga2/features-enabled/api.conf'
+    state: absent
+  notify: restart icinga2
+
+- import_tasks: icingaweb2.yml
+  when: icinga2.icingaweb2 is defined and icinga2.icingaweb2
+  tags:
+    - 'role::icingaweb2'
+
+- name: Disable IcingaWeb2 Apache configuration
+  when: icinga2.icingaweb2 is undefined or not icinga2.icingaweb2
+  file:
+    path: '/etc/apache2/conf-enabled/icingaweb2.conf'
+    state: absent
+  notify: reload apache2
+
+- name: Disable IcingaWeb2 Apache authentication
+  when: icinga2.icingaweb2 is undefined or not icinga2.icingaweb2
+  file:
+    path: '/etc/apache2/conf-enabled/icingaweb2-local.conf'
+    state: absent
+  notify: reload apache2

--- a/icinga2-server/templates/icinga2/conf.d/api-users.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/api-users.conf.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+
+/**
+ * The ApiUser objects are used for authentication against the API.
+ */
+
+{% for item in icinga2.userliste | default() | selectattr('user', 'defined') | selectattr('pw', 'defined') %}
+{% if item.user is defined and item.pw is defined %}
+object ApiUser "{{ item.user }}" {
+  password = "{{ item.pw }}"
+  permissions = [ "status/query", "objects/query/*", "actions/*" ]
+}
+
+{% endif %}
+{% endfor %}

--- a/icinga2-server/templates/icinga2/conf.d/app.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/app.conf.j2
@@ -1,0 +1,3 @@
+# {{ ansible_managed }}
+
+object IcingaApplication "app" { }

--- a/icinga2-server/templates/icinga2/conf.d/command-nrpe2.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/command-nrpe2.conf.j2
@@ -1,0 +1,47 @@
+# {{ ansible_managed }}
+
+object CheckCommand "nrpe2" {
+    import "ipv4-or-ipv6"
+
+    command = [ PluginDir + "/check_nrpe" ]
+
+    arguments = {
+	"-H" = "$nrpe_address$"
+	"-p" = "$nrpe_port$"
+	"-c" = "$nrpe_command$"
+	"-n" = {
+	    set_if = "$nrpe_no_ssl$"
+	    description = "Do not use SSL."
+	}
+	"-u" = {
+	    set_if = "$nrpe_timeout_unknown$"
+	    description = "Make socket timeouts return an UNKNOWN state instead of CRITICAL"
+	}
+	"-t" = "$nrpe_timeout$"
+	"-a" = {
+	    value = "$nrpe_arguments$"
+	    repeat_key = false
+	    order = 1
+	}
+	"-2" = {
+	    set_if = "$nrpe_v2$"
+	    description = "Use NRPE v2 only"
+	}
+	"-4" = {
+	    set_if = "$nrpe_ipv4$"
+	    description = "Use IPv4 connection"
+	}
+	"-6" = {
+	    set_if = "$nrpe_ipv6$"
+	    description = "Use IPv6 connection"
+	}
+    }
+
+    vars.nrpe_address = "$check_address$"
+    vars.nrpe_no_ssl = false
+    vars.nrpe_timeout_unknown = false
+    vars.check_ipv4 = "$nrpe_ipv4$"
+    vars.check_ipv6 = "$nrpe_ipv6$"
+    vars.nrpe_v2 = true
+    timeout = 5m
+}

--- a/icinga2-server/templates/icinga2/conf.d/commands.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/commands.conf.j2
@@ -1,0 +1,189 @@
+# {{ ansible_managed }}
+
+/* Command objects */
+
+/* Notification Commands
+ *
+ * Please check the documentation for all required and
+ * optional parameters.
+ */
+
+object NotificationCommand "mail-host-notification" {
+  command = [ ConfigDir + "/scripts/mail-host-notification.sh" ]
+
+  arguments += {
+    "-4" = "$notification_address$"
+    "-6" = "$notification_address6$"
+    "-b" = "$notification_author$"
+    "-c" = "$notification_comment$"
+    "-d" = {
+      required = true
+      value = "$notification_date$"
+    }
+    "-f" = {
+      value = "$notification_from$"
+      description = "Set from address. Requires GNU mailutils (Debian/Ubuntu) or mailx (RHEL/SUSE)"
+    }
+    "-i" = "$notification_icingaweb2url$"
+    "-l" = {
+      required = true
+      value = "$notification_hostname$"
+    }
+    "-n" = {
+      required = true
+      value = "$notification_hostdisplayname$"
+    }
+    "-o" = {
+      required = true
+      value = "$notification_hostoutput$"
+    }
+    "-r" = {
+      required = true
+      value = "$notification_useremail$"
+    }
+    "-s" = {
+      required = true
+      value = "$notification_hoststate$"
+    }
+    "-t" = {
+      required = true
+      value = "$notification_type$"
+    }
+    "-v" = "$notification_logtosyslog$"
+  }
+
+  vars += {
+    notification_address = "$address$"
+    notification_address6 = "$address6$"
+    notification_author = "$notification.author$"
+    notification_comment = "$notification.comment$"
+    notification_type = "$notification.type$"
+    notification_date = "$icinga.long_date_time$"
+    notification_hostname = "$host.name$"
+    notification_hostdisplayname = "$host.display_name$"
+    notification_hostoutput = "$host.output$"
+    notification_hoststate = "$host.state$"
+    notification_useremail = "$user.email$"
+  }
+}
+
+object NotificationCommand "mail-service-notification" {
+  command = [ ConfigDir + "/scripts/mail-service-notification.sh" ]
+
+  arguments += {
+    "-4" = "$notification_address$"
+    "-6" = "$notification_address6$"
+    "-b" = "$notification_author$"
+    "-c" = "$notification_comment$"
+    "-d" = {
+      required = true
+      value = "$notification_date$"
+    }
+    "-e" = {
+      required = true
+      value = "$notification_servicename$"
+    }
+    "-f" = {
+      value = "$notification_from$"
+      description = "Set from address. Requires GNU mailutils (Debian/Ubuntu) or mailx (RHEL/SUSE)"
+    }
+    "-i" = "$notification_icingaweb2url$"
+    "-l" = {
+      required = true
+      value = "$notification_hostname$"
+    }
+    "-n" = {
+      required = true
+      value = "$notification_hostdisplayname$"
+    }
+    "-o" = {
+      required = true
+      value = "$notification_serviceoutput$"
+    }
+    "-r" = {
+      required = true
+      value = "$notification_useremail$"
+    }
+    "-s" = {
+      required = true
+      value = "$notification_servicestate$"
+    }
+    "-t" = {
+      required = true
+      value = "$notification_type$"
+    }
+    "-u" = {
+      required = true
+      value = "$notification_servicedisplayname$"
+    }
+    "-v" = "$notification_logtosyslog$"
+  }
+
+  vars += {
+    notification_address = "$address$"
+    notification_address6 = "$address6$"
+    notification_author = "$notification.author$"
+    notification_comment = "$notification.comment$"
+    notification_type = "$notification.type$"
+    notification_date = "$icinga.long_date_time$"
+    notification_hostname = "$host.name$"
+    notification_hostdisplayname = "$host.display_name$"
+    notification_servicename = "$service.name$"
+    notification_serviceoutput = "$service.output$"
+    notification_servicestate = "$service.state$"
+    notification_useremail = "$user.email$"
+    notification_servicedisplayname = "$service.display_name$"
+  }
+}
+
+/*
+ * If you prefer to use the notification scripts with environment
+ * variables instead of command line parameters, you can use
+ * the following commands. They have been updated from < 2.7
+ * to support the new notification scripts and should help
+ * with an upgrade.
+ * Remove the comment blocks and comment the notification commands above.
+ */
+
+/*
+
+object NotificationCommand "mail-host-notification" {
+  command = [ ConfigDir + "/scripts/mail-host-notification.sh" ]
+
+  env = {
+    NOTIFICATIONTYPE = "$notification.type$"
+    HOSTDISPLAYNAME = "$host.display_name$"
+    HOSTNAME = "$host.name$"
+    HOSTADDRESS = "$address$"
+    HOSTSTATE = "$host.state$"
+    LONGDATETIME = "$icinga.long_date_time$"
+    HOSTOUTPUT = "$host.output$"
+    NOTIFICATIONAUTHORNAME = "$notification.author$"
+    NOTIFICATIONCOMMENT = "$notification.comment$"
+    HOSTDISPLAYNAME = "$host.display_name$"
+    USEREMAIL = "$user.email$"
+  }
+}
+
+object NotificationCommand "mail-service-notification" {
+  command = [ ConfigDir + "/scripts/mail-service-notification.sh" ]
+
+  env = {
+    NOTIFICATIONTYPE = "$notification.type$"
+    SERVICENAME = "$service.name$"
+    HOSTNAME = "$host.name$"
+    HOSTDISPLAYNAME = "$host.display_name$"
+    HOSTADDRESS = "$address$"
+    SERVICESTATE = "$service.state$"
+    LONGDATETIME = "$icinga.long_date_time$"
+    SERVICEOUTPUT = "$service.output$"
+    NOTIFICATIONAUTHORNAME = "$notification.author$"
+    NOTIFICATIONCOMMENT = "$notification.comment$"
+    HOSTDISPLAYNAME = "$host.display_name$"
+    SERVICEDISPLAYNAME = "$service.display_name$"
+    USEREMAIL = "$user.email$"
+  }
+}
+
+*/
+

--- a/icinga2-server/templates/icinga2/conf.d/notifications.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/notifications.conf.j2
@@ -1,0 +1,35 @@
+# {{ ansible_managed }}
+
+/**
+ * The example notification apply rules.
+ *
+ * Only applied if host/service objects have
+ * the custom attribute `notification` defined
+ * and containing `mail` as key.
+ *
+ * Check `hosts.conf` for an example.
+ */
+
+apply Notification "mail-icingaadmin" to Host {
+  import "mail-host-notification"
+  user_groups = host.vars.notification.mail.groups
+  users = host.vars.notification.mail.users
+
+  //interval = 2h
+
+  //vars.notification_logtosyslog = true
+
+  assign where host.vars.notification.mail
+}
+
+apply Notification "mail-icingaadmin" to Service {
+  import "mail-service-notification"
+  user_groups = host.vars.notification.mail.groups
+  users = host.vars.notification.mail.users
+
+  //interval = 2h
+
+  //vars.notification_logtosyslog = true
+
+  assign where host.vars.notification.mail
+}

--- a/icinga2-server/templates/icinga2/conf.d/templates.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/templates.conf.j2
@@ -1,0 +1,85 @@
+# {{ ansible_managed }}
+
+/*
+ * Generic template examples.
+ */
+
+
+/**
+ * Provides default settings for hosts. By convention
+ * all hosts should import this template.
+ *
+ * The CheckCommand object `hostalive` is provided by
+ * the plugin check command templates.
+ * Check the documentation for details.
+ */
+template Host "generic-host" {
+  max_check_attempts = 10
+  check_interval = 5m
+  retry_interval = 2m
+
+  check_command = "hostalive"
+}
+
+/**
+ * Provides default settings for services. By convention
+ * all services should import this template.
+ */
+template Service "generic-service" {
+  max_check_attempts = 10
+  check_interval = 5m
+  retry_interval = 2m
+}
+
+/**
+ * Provides default settings for users. By convention
+ * all users should inherit from this template.
+ */
+
+template User "generic-user" {
+
+}
+
+/**
+ * Provides default settings for host notifications.
+ * By convention all host notifications should import
+ * this template.
+ */
+template Notification "mail-host-notification" {
+  command = "mail-host-notification"
+
+  states = [ Up, Down ]
+  types = [ Problem, Acknowledgement, Recovery, Custom,
+            FlappingStart, FlappingEnd,
+            DowntimeStart, DowntimeEnd, DowntimeRemoved ]
+
+  vars += {
+    // notification_icingaweb2url = "https://www.example.com/icingaweb2"
+    // notification_from = "Icinga 2 Host Monitoring <icinga@example.com>"
+    notification_logtosyslog = false
+  }
+
+  period = "24x7"
+}
+
+/**
+ * Provides default settings for service notifications.
+ * By convention all service notifications should import
+ * this template.
+ */
+template Notification "mail-service-notification" {
+  command = "mail-service-notification"
+
+  states = [ OK, Warning, Critical, Unknown ]
+  types = [ Problem, Acknowledgement, Recovery, Custom,
+            FlappingStart, FlappingEnd,
+            DowntimeStart, DowntimeEnd, DowntimeRemoved ]
+
+  vars += {
+    // notification_icingaweb2url = "https://www.example.com/icingaweb2"
+    // notification_from = "Icinga 2 Service Monitoring <icinga@example.com>"
+    notification_logtosyslog = false
+  }
+
+  period = "24x7"
+}

--- a/icinga2-server/templates/icinga2/conf.d/timeperiods.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/timeperiods.conf.j2
@@ -1,0 +1,37 @@
+# {{ ansible_managed }}
+
+/**
+ * Sample timeperiods for Icinga 2.
+ * Check the documentation for details.
+ */
+
+object TimePeriod "24x7" {
+  display_name = "Icinga 2 24x7 TimePeriod"
+  ranges = {
+    "monday" 	= "00:00-24:00"
+    "tuesday" 	= "00:00-24:00"
+    "wednesday" = "00:00-24:00"
+    "thursday" 	= "00:00-24:00"
+    "friday" 	= "00:00-24:00"
+    "saturday" 	= "00:00-24:00"
+    "sunday" 	= "00:00-24:00"
+  }
+}
+
+object TimePeriod "9to5" {
+  display_name = "Icinga 2 9to5 TimePeriod"
+  ranges = {
+    "monday" 	= "09:00-17:00"
+    "tuesday" 	= "09:00-17:00"
+    "wednesday" = "09:00-17:00"
+    "thursday" 	= "09:00-17:00"
+    "friday" 	= "09:00-17:00"
+  }
+}
+
+object TimePeriod "never" {
+  display_name = "Icinga 2 never TimePeriod"
+  ranges = {
+  }
+}
+

--- a/icinga2-server/templates/icinga2/conf.d/users.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/users.conf.j2
@@ -1,0 +1,16 @@
+# {{ ansible_managed }}
+
+object UserGroup "freifunk_admins" {
+  display_name = "Freifunk-Adminstratoren"
+}
+
+{% for item in icinga2.userliste | default() | selectattr('email','defined') %}
+object User "{{ item.user | default(item.email) }}" {
+  import "generic-user"
+  groups = ["freifunk_admins"]
+
+  display_name = "{{ item.user | default(item.email) }}"
+  email = "{{ item.email }}"
+}
+
+{% endfor %}

--- a/icinga2-server/templates/icinga2/features/ido/ido-mysql.conf.j2
+++ b/icinga2-server/templates/icinga2/features/ido/ido-mysql.conf.j2
@@ -1,0 +1,15 @@
+# {{ ansible_managed }}
+
+/**
+ * The db_ido_mysql library implements IDO functionality
+ * for MySQL.
+ */
+
+library "db_ido_mysql"
+
+object IdoMysqlConnection "ido-mysql" {
+  user = "icinga2_ido",
+  password = "{{ lookup('password', '/tmp/mysqlpwd-icinga2_ido.ansible length=16') }}",
+  host = "localhost",
+  database = "icinga2_ido"
+}

--- a/icinga2-server/templates/icingaweb2/resources.ini.j2
+++ b/icinga2-server/templates/icingaweb2/resources.ini.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+
+[icinga_ido]
+type = "db"
+db = "mysql"
+host = "localhost"
+port = ""
+dbname = "icinga2_ido"
+username = "icinga2_ido"
+password = "{{ icinga2_ido_db_pw }}"
+charset = "utf8mb4"
+use_ssl = "0"
+

--- a/icinga2-server/templates/icingaweb2/roles.ini.j2
+++ b/icinga2-server/templates/icingaweb2/roles.ini.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+
+[Administratoren]
+users = "{{ icinga2.userliste | default() | selectattr('user','defined') | selectattr('pw', 'defined') | map(attribute='user') | list | join(",") }}"
+permissions = "*"


### PR DESCRIPTION
Wir setzen zum Monitoring Icinga2 ein, das über diese Rolle hier installiert wird. Wenn ihr das auch brauchen könnt dann könnt ihr das gerne bei euch aufnehmen.  Wenn nicht dann halt nicht.

Diese Rolle installiert Icinga2 und IcingaWeb2 und benötigt die Rolle exim4-daemon-light.

Die Konfiguration erfolgt durch Variable "icinga2":
```
    icinga2:
      api: true
      icingaweb2: true
      userliste:
        - user: username1
          pw: passwort1
          email: username1@foobar.com
        - user: username2
          pw: passwort2
        - email: beispiel@bar.baz
```
-  **api:** Icinga2-API ein- (=true) oder ausschalten (=false). Standard: false. Über die API ist nur Monitoring erlaubt, kein Anlegen/Ändern/Löschen von Objekten u.ä.
- **icingaweb2:** IcingaWeb2-Weboberfläche ein- (=true) oder ausschalten (=false). Standard: false
- **userliste:** Enthält eine Liste mit Benutzern. Ein Benutzer muss Benutzername und Passwort und/oder E-Mailadresse haben.

Wenn die Icinga2-API und/oder IcingaWeb2 eingeschaltet ist, dann haben alle in "userliste" mit Benutzername ("user") und Passwort ("pw") angebenen Benutzer darauf Zugriff.
An alle in "userliste" angegebenen E-Mail-Adressen ("email") versendet Icinga2 Notifications. Dazu ist die Rolle exim4-daemon-light nötig, die die E-Mails lokal annimmt und an einen SMTP-Server weiterleitet.

Im Beispiel oben gibt es drei User: Zwei davon können sich an der API und an IcingaWeb2 anmelden, einer davon bekommt die Alerts zusätzlich per E-Mail. Der dritte User kann sich nirgends anmelden und wird nur per E-Mail über Alerts informiert.