### PR TITLE
nrpe, check_bat(6): Stabilere Prüfung

### DIFF
--- a/nrpe/templates/check_batip.j2
+++ b/nrpe/templates/check_batip.j2
@@ -80,12 +80,12 @@ COUNTOK=0
 
 for a in $CHECKIP ; do
   #echo $IPBASE$a
-  ping  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
+  ping  -c 1 -W 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
 done
 
 #echo es antworten $COUNTOK IPs 
 
-if [ $COUNTOK -le $COUNTREQUIRED ]; then
+if [ $COUNTOK -lt $COUNTREQUIRED ]; then
   echo "CRITICAL: Es antworten nur $COUNTOK der Domain-IPs $CHECKIP"
   exit $STATE_CRITICAL
 else

--- a/nrpe/templates/check_batip6.j2
+++ b/nrpe/templates/check_batip6.j2
@@ -82,12 +82,12 @@ COUNTOK=0
 
 for a in $CHECKIP ; do
   # echo $IPBASE$a
-  ping6  -c 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
+  ping6  -c 1 -W 1 $IPBASE$a > /dev/null && COUNTOK=$[COUNTOK+1] 
 done
 
 #echo es antworten $COUNTOK IPs 
 
-if [ $COUNTOK -le $COUNTREQUIRED ]; then
+if [ $COUNTOK -lt $COUNTREQUIRED ]; then
   echo "CRITICAL: Es antworten nur $COUNTOK der V6Domain-IPs $CHECKIP"
   exit $STATE_CRITICAL
 else


### PR DESCRIPTION
- Erst vor Batman-Ausfall warnen wenn **weniger** als die erforderliche
Host-Anzahl nicht mehr erreichbar ist. Bisher gibt es bereits einen
Alert wenn die Hälfte der Hosts nicht erreichbar ist. Dies führt dazu,
dass bei kleinen Communities mit nur zwei Gateways beim jedem Reboot eines Gateways
fälschlicherweise ein Batman-Ausfall diagnostiziert wird.
- Ping-Timeout auf 1 Sekunde verkürzt um NRPE-Timout (Default: 10s, genau wie der Ping-Timeout) samt "STATE UNKNOWN"-Alert bei Ausfall eines einzigen zu prüfenden Hosts zu vermeiden.