### PR TITLE
gateways_l2tp_slovenija: Aktueller tunneldigger benötigt Python3

### DIFF
--- a/gateways_l2tp_slovenija/tasks/main.yml
+++ b/gateways_l2tp_slovenija/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install dependencies for this role
   apt:
-    pkg: ['git', 'libnetfilter-conntrack-dev', 'libnfnetlink-dev', 'python-dev', 'python-virtualenv', 'gcc',
-      'libnl-3-dev', 'libffi-dev', 'libevent-dev', 'libnetfilter-conntrack3', 'bridge-utils', 'ebtables', 'iproute2']
+    pkg: ['git', 'libnetfilter-conntrack-dev', 'libnfnetlink-dev', 'python3-dev', 'python-virtualenv', 'gcc',
+      'libnl-3-dev', 'libevent-dev', 'bridge-utils', 'ebtables', 'iproute2']
   when: domaenenliste is defined
 
 - name: Get all enabled tunneldigger (domain specific) instances
@@ -33,17 +33,19 @@
 
 - name: generate virtualenv.
   command:
-    "virtualenv env_tunneldigger"
+    "virtualenv -p /usr/bin/python3 env_tunneldigger"
   args:
     chdir: /srv/tunneldigger/
     creates: "/srv/tunneldigger/env_tunneldigger/bin/python"
   when: domaenenliste is defined
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Install python dependencies
   command: "/srv/tunneldigger/env_tunneldigger/bin/python setup.py install"
   args:
     chdir: /srv/tunneldigger/broker
   when: domaenenliste is defined
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Deploy addif.sh for each domain
   template: src=addif.sh.j2 dest="/srv/tunneldigger/broker/scripts/addif_domain{{ item.key }}.sh" mode=0755


### PR DESCRIPTION
Tunneldigger benötigt seit kurzem Python3. Darum:
- statt python-dev jetzt python3-dev installieren
- virtualenv mit Python3 erstellen

Außerdem wird mittlerweile libffi-dev nicht mehr benötigt. Auf die explizite Installation von libnetfilter-conntrack3 kann verzichtet werden, da libnetfilter-conntrack-dev hart davon abhängt.

Wenn die Rolle im Ansible-Check-Mode auf einem Server "ausgerollt" wird, auf dem sie bis jetzt noch nicht installiert war, bricht sie bisher ab, weil das Verzeichnis "/srv/tunneldigger/" noch nicht existiert. Dieser Fehler wird jetzt ignoriert und führt im Check-Mode nicht mehr zum Abbruch.
