### PR TITLE
gateways_l2tp_slovenija: Behebe Probleme beim Stoppen

### DIFF
--- a/gateways_l2tp_slovenija/files/tunneldigger@.service
+++ b/gateways_l2tp_slovenija/files/tunneldigger@.service
@@ -7,6 +7,7 @@ Type=simple
 WorkingDirectory=/srv/tunneldigger
 ExecStart=/srv/tunneldigger/env_tunneldigger/bin/python -m tunneldigger_broker.main /srv/tunneldigger/broker/l2tp_broker_domain%i.cfg
 KillMode=process
+KillSignal=SIGINT
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
Wenn der tunneldigger mit `systemctl stop tunneldigger@XX` gestoppt wird, bleiben iptables-Regeln übrig:

```
root@gw3 ~ # iptables -t nat -L PREROUTING 
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination         
L2TP_PREROUTING_domaene_10  all  --  anywhere             anywhere  
```

```
root@gw3 ~ # iptables -t nat -L POSTROUTING
Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination         
L2TP_POSTROUTING_domaene_10  all  --  anywhere             anywhere            
SNAT       all  --  10.10.0.0/16         anywhere             to:185.66.194.6
```


Wird nun tunneldigger erneut gestartet (ganz gleich ob mit oder ohne systemd), bricht er ab:
```
root@gw3 /srv # /srv/tunneldigger/env_tunneldigger/bin/python -m tunneldigger_broker.main /srv/tunneldigger/broker/l2tp_broker_domain10.cfg
[INFO/tunneldigger.broker] Initializing the tunneldigger broker.
[INFO/tunneldigger.broker] Registered script '/srv/tunneldigger/broker/scripts/addif_domain10.sh' for hook 'session.up'.
[INFO/tunneldigger.broker] Registered script '/srv/tunneldigger/broker/scripts/delif_domain10.sh' for hook 'session.pre-down'.
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/srv/tunneldigger/env_tunneldigger/lib/python3.7/site-packages/tunneldigger_broker-0.3.0-py3.7-linux-x86_64.egg/tunneldigger_broker/main.py", line 84, in <module>
    tunnel_manager.initialize()
  File "/srv/tunneldigger/env_tunneldigger/lib/python3.7/site-packages/tunneldigger_broker-0.3.0-py3.7-linux-x86_64.egg/tunneldigger_broker/broker.py", line 176, in initialize
    nat.create_chain(postrouting_chain)
  File "/srv/tunneldigger/env_tunneldigger/lib/python3.7/site-packages/netfilter-0.6.4-py3.7.egg/netfilter/table.py", line 65, in create_chain
  File "/srv/tunneldigger/env_tunneldigger/lib/python3.7/site-packages/netfilter-0.6.4-py3.7.egg/netfilter/table.py", line 154, in __run_iptables
  File "/srv/tunneldigger/env_tunneldigger/lib/python3.7/site-packages/netfilter-0.6.4-py3.7.egg/netfilter/table.py", line 170, in __run
netfilter.table.IptablesError: command: ['iptables', '--wait', '-t', 'nat', '-N', 'L2TP_POSTROUTING_domaene_10']
message: iptables v1.8.2 (nf_tables): Chain already exists
```

Wenn zum Stoppen von Tunneldigger SIGINT statt dem standardmäßigen SIGTERM benutzt wird, werden die iptables-Regeln brav aufgeräumt bevor tunneldigger beendet wird, und dem nächsten Start von tunneldigger steht nichts im Weg.