### PR TITLE
gateways_bind: Erlaube DNS-Roundrobin-Konfiguration

### DIFF
--- a/gateways_bind/templates/db.ffnet.j2
+++ b/gateways_bind/templates/db.ffnet.j2
@@ -21,11 +21,23 @@ freifunk			IN      A       {{domaenen[item].ffv4_network | ipaddr(1) | ipaddr('a
 freifunk			IN      AAAA    {{domaenen[item].ffv6_network | ipaddr(1) | ipaddr('address')}}
 {% if freifunk.ffnet_dns_entries_for_internal_tld is defined -%}
 {% for entry in freifunk.ffnet_dns_entries_for_internal_tld %}
-{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].A is defined -%}
-{{entry}}	IN	A	{{freifunk.ffnet_dns_entries_for_internal_tld[entry].A}}
-{% endif -%} 
-{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA is defined -%}
-{{entry}}	IN	AAAA	{{freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA}}
-{% endif -%}
+{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].A is defined %}
+{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].A is string %}
+{{entry}}	IN	A	{{ freifunk.ffnet_dns_entries_for_internal_tld[entry].A }}
+{% elif freifunk.ffnet_dns_entries_for_internal_tld[entry].A is iterable %}
+{% for subentry in freifunk.ffnet_dns_entries_for_internal_tld[entry].A %}
+{{entry}}	IN	A	{{subentry}}
 {% endfor %}
 {% endif %}
+{% endif %}
+{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA is defined %}
+{% if freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA is string %}
+{{entry}}	IN	AAAA	{{ freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA }}
+{% elif freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA is iterable %}
+{% for subentry in freifunk.ffnet_dns_entries_for_internal_tld[entry].AAAA %}
+{{entry}}	IN	AAAA	{{subentry}}
+{% endfor %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% endif -%}

--- a/gateways_bind/templates/named.conf.options.j2
+++ b/gateways_bind/templates/named.conf.options.j2
@@ -22,6 +22,7 @@ options {
 	tcp-clients 1000;
 	recursive-clients 10000;
 
+        rrset-order { order random; };
 };
 {% if collectd is defined and collectd.collect_bind %}
 statistics-channels {


### PR DESCRIPTION
Statt nur einer einzigen IP-Adresse können pro Hostname mehrere IP-Adressen angegeben werden.

Konfigurationsbeispiel (in group_vars/all):
```
  ffnet_dns_entries_for_internal_tld:
    "foo":
      A: 11.11.11.11
    "bar":
      A:    22.22.22.22
      AAAA: 2a03:2260::22
    "baz":
      A:
        - 33.33.33.33
        - 44.44.44.44
      AAAA:
        - 2a03:2260::33
        - 2a03:2260::44
```

Ergibt dann im Zonefile /etc/bind/db.domaene-XX.ffnet:
```
  foo    IN      A       11.11.11.11
  bar    IN      A       22.22.22.22
  bar    IN      AAAA    2a03:2260::22
  baz    IN      A       33.33.33.33
  baz    IN      A       44.44.44.44
  baz    IN      AAAA    2a03:2260::33
  baz    IN      AAAA    2a03:2260::44
```