### PR TITLE
Allow port blockage (e. g. 25/SMTP) via blocked_tcp|udp_ports

### DIFF
--- a/iptables/templates/rules.v4.j2
+++ b/iptables/templates/rules.v4.j2
@@ -3,9 +3,18 @@
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
+{% if blocked_tcp_ports is defined %}
+{% for port in blocked_tcp_ports %}
+-A FORWARD -p tcp --dport {{port}}  -j DROP
+{% endfor %}
+{% endif %}
+{% if blocked_udp_ports is defined %}
+{% for port in blocked_udp_ports %}
+-A FORWARD -p udp --dport {{port}}  -j DROP
+{% endfor %}
+{% endif %}
 :OUTPUT ACCEPT [0:0]
 -A INPUT -p udp -m udp --dport 111 -j DROP
-
 COMMIT
 *nat
 :PREROUTING ACCEPT [0:0]

--- a/iptables/templates/rules.v6.j2
+++ b/iptables/templates/rules.v6.j2
@@ -3,6 +3,16 @@
 *filter
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
+{% if blocked_tcp_ports is defined %}
+{% for port in blocked_tcp_ports %}
+-A FORWARD -p tcp --dport {{port}}  -j DROP
+{% endfor %}
+{% endif %}
+{% if blocked_udp_ports is defined %}
+{% for port in blocked_udp_ports %}
+-A FORWARD -p udp --dport {{port}}  -j DROP
+{% endfor %}
+{% endif %}
 :OUTPUT ACCEPT [0:0]
 COMMIT
 *mangle


### PR DESCRIPTION
Neuer Anlauf ...

```
root@aux01:~/ffue-ansible# grep -A2 -B2 blocked_ group_vars/all
    dummy: true

blocked_tcp_ports:
 - 25


```

```
root@aux01:~/ffue-ansible# grep -A2 -B2 blocked_ host_vars/ffue-gw01 


blocked_tcp_ports:
 - 23


```

Um ein globales Blocking (group_vars/all) auf Hostebene (host_vars/host) zu deaktivieren, müßte man derzeit einen Dummy-Port blocken, aber ich denke Port 1 kann man notfalls immer gefahrlos sperren.