### PR TITLE
Force usage of own IPv6 prefix.

### DIFF
--- a/backbone_gre_intern/templates/gre_interbackbone.j2
+++ b/backbone_gre_intern/templates/gre_interbackbone.j2
@@ -14,11 +14,12 @@ iface bck-{{host}} inet static
         pre-up ip link set $IFACE up multicast on
         post-up ip rule add iif $IFACE table ffnet
         pre-down ip rule del iif $IFACE table ffnet ||:
+
 iface bck-{{host}} inet6 static
 {% if hostvars[host].vm_id < vm_id %}
-        address 2a03:2260:115:ffa1::{{hostvars[host].vm_id}}:{{vm_id}}:0
+        address {{ipv6backbone64prefixstr}}{{hostvars[host].vm_id}}:{{vm_id}}:0
 {% else %}
-        address 2a03:2260:115:ffa1::{{vm_id}}:{{hostvars[host].vm_id}}:1
+        address {{ipv6backbone64prefixstr}}{{vm_id}}:{{hostvars[host].vm_id}}:1
 {% endif %}
         netmask 127
         post-up ip -6 rule add iif $IFACE table ffnet


### PR DESCRIPTION
Wie schon diskutiert:

Über ipv6backbone64prefixstr **muß** der interne v6-Präfix für Tunnel gesetzt werden — 2a03:2260:115:ffa1:: darf nur FFMS nutzen. (Bisherige Nutzer werden das ggf. aus Opportunitätsgründen ebenfalls weiterhin nutzen wollen, aber das ist dann zumindest eine explizite Entscheidung.) 

Aus der bisherigen Diskussion: 

@MPW1412 schrieb:

> Könnte man das nicht vom Präfix dynamisch ableiten und dann einen festen vierten Block verwenden?
> 
> Ich finde es immer praktisch, möglichst viel dynamisch aus möglichst wenig Variablen zu generieren.

@wusel42 antwortete:

> V6-Präfix: den abzuleiten halte ich für ungünstig, denn damit definierst Du einen Bereich im /48 oder größer (/44 $hier), der im Netzplan ggf. anders verplant ist. Wir nutzen für Infra z. B. auch anderen Block als für Mesh.

Konkret:
```
root@aux01:~/ffue-ansible# grep ipv6back ../test-ansible-ffms.git/group_vars/gateways ; grep ffv6_network ../test-ansible-ffms.git/group_vars/all
ipv6backbone64prefixstr: "2a06:e881:1705:ffff::"
    ffv6_network: 2001:bf7:1310:128::/64
    ffv6_network: 2001:bf7:1310:160::/64
    ffv6_network: 2001:bf7:1310:176::/64
    ffv6_network: 2001:bf7:1310:144::/64
    ffv6_network: 2001:bf7:170:192::/64
    ffv6_network: 2001:bf7:170:64::/64
    ffv6_network: 2001:bf7:1310:666::/64
    ffv6_network: 2001:bf7:1310:fcfc::/64
    ffv6_network: 2001:bf7:1310:abcd::/64
    ffv6_network: 2001:bf7:170:1::/64
    ffv6_network: 2001:bf7:1310:dead::/64

```
Falls Du auf ff_network.v6_network abstellst, das tut $hier leider gar nicht:

```
ff_network:
  # Eindeutige AS-Nummer des Netzwerk
  as_number: 206813
  # IPv4 Adressraum
  v4_network: 10.234.0.0/15
  # IPv6 adressraum
  v6_network: 8733::/48 # v6_network wird als unreachable exportiert (static_Gesamtnetzwerk); da wir u. a. 2001:bf7:1310::/44 und 2001:bf7:170::/44 nutzen, 2001:bf7::/32 aber more specific als ::/0 ist, muß hier ein Dummy-Eintrag hin. Ja, besser wäre ULA ;)

```

Kurzum: mit mehr als einen /48 ist die Ableitung schwierig, das sollte man schon den Admins überlassen, was sie da nutzen wollen.