### PR TITLE
Erlaube sprechende Namensgebung und entfernte Datenhaltung

### DIFF
--- a/mapserver_hopglass/tasks/main.yml
+++ b/mapserver_hopglass/tasks/main.yml
@@ -88,7 +88,7 @@
     path: /opt/hopglass/client/build/config/
     state: directory
 
-- name: Deploy config.json domainspecific
+- name: Deploy domainspecific config.json files
   template:
     src: configdom.json.j2
     dest: "/opt/hopglass/client/build/config/config_{{item[0]}}.json"

--- a/mapserver_hopglass/templates/config.json.j2
+++ b/mapserver_hopglass/templates/config.json.j2
@@ -1,5 +1,11 @@
+{% set proxy_urls = [] %}
+{% for domain in domaenen|dictsort %}
+{% if domain[1].proxy_map_data_url is defined and domain[1].proxy_map_data_url %}
+{% if proxy_urls.append(domain[1].site_code) %}{% endif %}
+{% endif %}
+{% endfor %}
 {
-  "dataPath": "/data/",
+  "dataPath": [ {% for url in proxy_urls %}"/proxy_{{ url }}/",{% endfor %}"/data/" ],
   "siteName": "{{freifunk.name}}",
   "mapSigmaScale": {{ mapconfig.globalMap.map_scale }},
   "showContact": {{ mapconfig.globalMap.map_show_contact | lower}},
@@ -17,6 +23,7 @@
         "{{k}}": {% if v is number %}{{v}}{% else %}"{{v}}"{% endif %}{% if not loop.last %},{% endif %}
 
 {% endfor %}
+
       }
     }{% if not loop.last %},{% endif %}
 
@@ -24,8 +31,7 @@
   ],
   "siteNames": [
 {% for domaene in domaenen|dictsort %}
-    { "site": "{{freifunk.kurzname}}d{{domaene[0]}}", "name": "Domäne {{domaene[0]}} - {{domaene[1].name}}" }{% if not loop.last %},{% endif %}
-
+    { "site": "{{domaene[1].site_code}}", "name": "Mesh {{domaene[0]}} - {{domaene[1].name}}" }{% if not loop.last %},{% endif %}
 {% endfor %}
   ],
 {% if mapconfig.globalInfos is defined %}

--- a/mapserver_hopglass/templates/configcommunity.json.j2
+++ b/mapserver_hopglass/templates/configcommunity.json.j2
@@ -5,8 +5,8 @@
 {% endif %}
 {% endfor %}
 {
-  "dataPath": "/data/map_{% for domain in map_domains %}{{freifunk.kurzname}}d{{domain[0]}}{% if not loop.last %},{% endif %}{% endfor %}/",
-  "siteName": "Freifunk {{item}}",
+  "dataPath": [ {% for domain in map_domains %}{% if domaenen[domain[0]].proxy_map_data_url is defined and domaenen[domain[0]].proxy_map_data_url %}"/proxy_{{ domaenen[domain[0]].site_code }}/"{% else %}"/data/map_{{ domain[0] }}/"{% endif %}{% if not loop.last %},{% endif %}{% endfor %} ],
+  "siteName": "Karte {{item}}",
   "mapSigmaScale": {{ mapconfig.communityMap.map_scale }},
   "showContact": {{ mapconfig.communityMap.map_show_contact | lower}},
   "maxAge": {{ mapconfig.communityMap.map_max_age }},
@@ -30,7 +30,7 @@
   ],
   "siteNames": [
 {% for domain in map_domains %}
-    { "site": "{{freifunk.kurzname}}d{{domain[0]}}", "name": "Domäne {{domain[0]}} - {{domain[1].name}}" }{% if not loop.last %},{% endif %}
+    { "site": "{{domain[1].site_code}}", "name": "Mesh {{domain[0]}} - {{domain[1].name}}" }{% if not loop.last %},{% endif %}
 
 {% endfor %}
   ],

--- a/mapserver_hopglass/templates/configdom.json.j2
+++ b/mapserver_hopglass/templates/configdom.json.j2
@@ -1,6 +1,10 @@
 {
-  "dataPath": "/data/map_{{freifunk.kurzname}}d{{item[0]}}/",
-  "siteName": "{% if item[1].community is defined %}Freifunk {{item[1].community}}{% else %}{{freifunk.name}}{% endif %} - Domäne {{item[1].name}}",
+{% if item[1].proxy_map_data_url is defined and item[1].proxy_map_data_url %}
+  "dataPath": "/proxy_{{item[1].site_code}}/",
+{% else %}
+  "dataPath": "/data/map_{{item[0]}}/",
+{% endif %}
+  "siteName": "{% if item[1].community is defined %}Karte {{item[1].community}}{% else %}{{freifunk.name}}{% endif %} - Mesh {{item[1].name}}",
   "mapSigmaScale": {{item[1].map_scale}},
   "showContact": {{item[1].map_show_contact | lower}},
   "maxAge": {{item[1].map_max_age}},
@@ -23,7 +27,7 @@
 {% endfor %}
   ],
   "siteNames": [
-    { "site": "{{freifunk.kurzname}}d{{item[0]}}", "name": "Domäne {{item[0]}} - {{item[1].name}}" }
+    { "site": "{{item[1].site_code}}", "name": "Mesh {{item[0]}} - {{item[1].name}}" }
   ],
 {% if mapconfig.globalInfos is defined %}
   "globalInfos": [

--- a/mapserver_nginx/templates/default_ssl.j2
+++ b/mapserver_nginx/templates/default_ssl.j2
@@ -51,11 +51,39 @@ server {
         gzip_types              text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
     }
 
+    # Proxy for external map data (if any)
+{% for domaene in domaenen|dictsort %}
+{% if domaene[1].proxy_map_data_url is defined and domaene[1].proxy_map_data_url %}
+    location /proxy_{{domaene[1].site_code}}/ {
+        #proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+
+        proxy_pass              {{ domaene[1].proxy_map_data_url }};
+        proxy_redirect          off;
+
+        proxy_cache             hopglass;
+        proxy_cache_valid       2m;
+
+        # enable gzip compression
+        gzip                    on;
+        gzip_http_version       1.0;
+        gzip_vary               on;
+        gzip_comp_level         4;
+        gzip_proxied            any;
+        gzip_types              text/plain text/css text/javascript application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss;
+    }
+{% endif %}
+{% endfor %}
+
     # Proxy for mapdata
     location /data/ {
-
-        # mapdata foreach domain, because hopglass can't handle args in uri)
-        rewrite "^/data/map_([^/]+)/(.+)$" /$2?filter=site&value=$1 break;
+        # mapdata for each domain, because hopglass can't handle args in uri
+{% for domaene in domaenen|dictsort %}
+        rewrite "^/data/map_{{domaene[0]}}/(.+)$" /$1?filter=site&value={{domaenen[domaene[0]].site_code}} break;
+{% endfor %}
+        #rewrite "^/data/map_([^/]+)/(.+)$" /$2?filter=site&value=$1 break;
 
         proxy_set_header        Host $host;
         proxy_set_header        X-Real-IP $remote_addr;

--- a/mapserver_nginx/templates/index.html.j2
+++ b/mapserver_nginx/templates/index.html.j2
@@ -26,7 +26,7 @@
       </div>
       <div class="col-md-10 col-sm-9">
         <h2>Karten - {{freifunk.name}}
-    <br/><small>Karten der einzelnen Domänen und der Communities</small></h2>
+    <br/><small>Karten der einzelnen Meshes und der Communities</small></h2>
       </div>
     </div>
     </div>
@@ -49,7 +49,7 @@
         </div>
         </form>
       <br/>
-      <h4><strong><a href="map/">Gesamtkarte des {{freifunk.name}}</a></strong></h4>
+      <h4><strong><a href="map/">Gesamtkarte {{freifunk.name}}</a></strong></h4>
       <p><a class="btn-ffms-collapse visible-xs" data-toggle="collapse" data-target="#narrow-results">&#187; Mehr Freifunk Links</a></p>
       <div id="narrow-results" class="narrow-results collapse">
 {% if indexconfig.links is defined %}
@@ -66,7 +66,7 @@
           <thead>
             <tr>
               <th>
-                  <div style=text-align:center><h4>Domänen</h4></div>
+                  <div style=text-align:center><h4>Meshes</h4></div>
               </th>
             </tr>
           </thead>
@@ -104,7 +104,7 @@
 {% for community in communities %}
 {% if community != "None" %}
             <tr>
-                <td><a Community href="map_{{community}}/">Community {{community}}</a><br/> <span class="ffms-muted">Domänen:</span>  
+                <td><a Community href="map_{{community}}/">Community {{community}}</a><br/> <span class="ffms-muted">Meshes:</span>  
 {% for domaene in domaenen|dictsort %}
 {% if community == domaene[1].community %}
                     <a href="map{{domaene[0]}}/">{{domaene[0]}}</a>


### PR DESCRIPTION
Der FFMSL-Ansatz impliziert, daß die Domänen durchnummeriert werden und mit "dXX" die Domäne XX adressiert werden kann. »Gewachsene« Netze haben eher »sprechende« Namen für ihre Meshes (in spe), seien es "gut", "rhw", "wrz" oder "ffce", "ffue", "ffwob". Mit diesem Patchset wird einerseits eine freie Namenswahl ("gut" statt "d01") ermöglicht, ferner die Einbindung externer Quellen per Proxy: "proxy_map_data_url: http://192.251.226.118/yanic/ffgt/". PoC: https//owlmap.4830.org
