### PR TITLE
gateways_l2tp_slovenija: Fix - Repariere Upgrade auf Python3

### DIFF
--- a/gateways_l2tp_slovenija/files/tunneldigger@.service
+++ b/gateways_l2tp_slovenija/files/tunneldigger@.service
@@ -5,7 +5,7 @@ After=network.target auditd.service
 [Service]
 Type=simple
 WorkingDirectory=/srv/tunneldigger
-ExecStart=/srv/tunneldigger/env_tunneldigger/bin/python -m tunneldigger_broker.main /srv/tunneldigger/broker/l2tp_broker_domain%i.cfg
+ExecStart=/srv/tunneldigger/env_tunneldigger/bin/python3 -m tunneldigger_broker.main /srv/tunneldigger/broker/l2tp_broker_domain%i.cfg
 KillMode=process
 KillSignal=SIGINT
 Restart=on-failure

--- a/gateways_l2tp_slovenija/tasks/main.yml
+++ b/gateways_l2tp_slovenija/tasks/main.yml
@@ -36,7 +36,7 @@
     "virtualenv -p /usr/bin/python3 env_tunneldigger"
   args:
     chdir: /srv/tunneldigger/
-    creates: "/srv/tunneldigger/env_tunneldigger/bin/python"
+    creates: "/srv/tunneldigger/env_tunneldigger/bin/python3"
   when: domaenenliste is defined
   ignore_errors: "{{ ansible_check_mode }}"
 


### PR DESCRIPTION
Wenn bestehende Tunneldigger-Installationen aktualisiert werden, startet danach Tunneldigger nicht mehr: "python" zeigt im Virtualenv weitherin auf python2, deswegen muss explizit "python3" benutzt werden.
Bei Neuinstallationen gibt's das Problem nicht. Auch dort schadet es aber nicht, "python3" statt "python" zu verwenden.