### PR TITLE
ntp: Fix - Repariere Pfad zum Konfigurationsdatei-Template

### DIFF
--- a/ntp/tasks/main.yml
+++ b/ntp/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Install chrony.conf
   template:
-    src: ntp.conf.j2
+    src: chrony.conf.j2
     dest: /etc/chrony/chrony.conf
   notify: Restart chrony
 


### PR DESCRIPTION
In der Ansible-Rolle wurde noch das Template für NTP statt für chrony referenziert.