### PR TITLE
gateways_dhcp: Fix für check_mode

### DIFF
--- a/gateways_dhcp/tasks/main.yml
+++ b/gateways_dhcp/tasks/main.yml
@@ -5,6 +5,7 @@
   register: kea_dhcp4_exists
   failed_when: not (kea_dhcp4_exists.rc == 0 or kea_dhcp4_exists.rc == 1)
   changed_when: false
+  check_mode: no
 
 - name: stop and disable Kea dhcpd
   systemd:


### PR DESCRIPTION
Shell-Befehl zur Prüfung, ob kea-dhcp installiert ist, auch im check-mode ausführen. Damit läuft die Rolle jetzt auch im check-mode durch.