### PR TITLE
Network related changes

### DIFF
--- a/bird/tasks/main.yml
+++ b/bird/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: calculate more specific routes for DHCP pools
   shell: |
     set -o pipefail
-    ipcalc {{ domaenenliste[item].dhcp_start }} - {{ domaenenliste[item].dhcp_ende }} | \
+    echo 240.255.255.255/32 | \
     grep -v "deaggregate" | sed -e 's/\(^.*$\)/route \1 via "bat{{ item }}";/g'
   args:
     executable: bash

--- a/bird/templates/bird.conf.j2
+++ b/bird/templates/bird.conf.j2
@@ -5,6 +5,30 @@ router id {{ vm_id }};
 
 table ffnet;
 
+function is_default() {
+	return (net ~ [0.0.0.0/0]);
+};
+
+filter freifunk {
+{% if ffrl_tun is defined %}
+	# FFRL
+	if net ~ [185.66.192.0/22+] then accept;
+{% endif %}
+{% if ffnw_tun is defined %}
+	# FFNW
+	if net ~ [185.197.132.0/24+] then accept;
+{% endif %}
+
+	if net ~ [10.0.0.0/8+] then accept;
+{% if not ffrl_tun is defined and not ffnw_tun is defined %}
+	if net ~ [0.0.0.0/0] then accept;
+{% endif %}
+
+	# interne Tunnel-IPs
+	if net ~ [192.168.0.0/16+] then accept;
+	reject;
+};
+
 protocol kernel 'kernel_ffnet' {
         scan time 20;
         import all;
@@ -70,34 +94,52 @@ protocol static dhcp_Bereich {
 }
 {% endif %}
 
-filter freifunk {
-{% if ffrl_tun is defined %}
-	# FFRL
-	if net ~ [185.66.192.0/22+] then accept;
+filter hostroute {
+{% if ffrl_nat_ip is defined %}
+	if net ~ {{ffrl_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-{% if ffnw_tun is defined %}
-	# FFNW
-	if net ~ [185.197.132.0/24+] then accept;
+{% if ffnw_nat_ip is defined %}
+	if net ~ {{ffnw_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-
-	if net ~ [10.0.0.0/8+] then accept;
-{% if not ffrl_tun is defined and not ffnw_tun is defined %}
-	if net ~ [0.0.0.0/0] then accept;
+{% if ospf_nat_ip is defined %}
+	if net ~ {{ospf_nat_ip | ipaddr('address')}}/32 then accept;
 {% endif %}
-
-	# interne Tunnel-IPs
-	if net ~ [192.168.0.0/16+] then accept;
 	reject;
 };
 
+{% if ospf_nat_ip is defined %}
+protocol ospf upstream {
+	table ffnet;
+	import where is_default();
+	export filter hostroute;
+{% if ospf_nat_instanceid is defined %}
+	instance id {{ospf_nat_instanceid}};
+{% endif %}
 
-protocol ospf {
+{% if ospf_nat_area is defined %}
+	area {{ospf_nat_area}} {
+{% else %}
+	area 0.0.0.0 {
+{% endif %}
+	    interface "{{ansible_default_ipv4.interface}}" {
+                cost 10;
+{% if ospf_nat_options is defined %}
+            	{{ospf_nat_options}}
+{% endif %}
+	    };
+	    interface "lo" { stub; };
+	};
+};
+{% endif %}
+
+protocol ospf backbone {
 	table ffnet;
 	import filter freifunk;
 	export filter {
 		if net ~ [192.168.0.0/16+] then reject;
 		accept;
 	};
+
 	area 0.0.0.0 {
 		interface "bat*" {
 			stub;
@@ -109,7 +151,10 @@ protocol ospf {
 		};
 {% endif %}
 {% endfor %}
-		interface "bck-*";
+		interface "bck-*" {
+			cost 1000;
+		};
+
 		interface "lo" {
 			stub;
 		};
@@ -131,21 +176,7 @@ protocol static {
         export none;
 };
 
-filter hostroute {
-{% if ffrl_nat_ip is defined %}
-	if net ~ {{ffrl_nat_ip | ipaddr('address')}}/32 then accept;
-{% endif %}
-{% if ffnw_nat_ip is defined %}
-	if net ~ {{ffnw_nat_ip | ipaddr('address')}}/32 then accept;
-{% endif %}
-	reject;
-};
-
 {% if ffrl_tun is defined or ffnw_tun is defined %}
-function is_default() {
-	return (net ~ [0.0.0.0/0]);
-};
-
 template bgp uplink {
 	table ffnet;
 	local as {{ff_network.as_number}};

--- a/bird/templates/bird6.conf.j2
+++ b/bird/templates/bird6.conf.j2
@@ -5,6 +5,10 @@ router id {{ vm_id }};
 
 table ffnet;
 
+function is_default() {
+	return (net ~ [::/0]);
+};
+
 filter freifunk {
 	if net ~ {{ff_network.v6_network}} then accept;
 {% if not ffrl_tun is defined %}
@@ -13,7 +17,7 @@ filter freifunk {
 	reject;
 }
 
-protocol kernel {
+protocol kernel  'kernel_ffnet' {
 	scan time 20;
 	import all;
 	export all;
@@ -34,11 +38,20 @@ protocol radv {
 		rdnss {
 			ns {{domaenen[domaene[0]].ffv6_network | ipaddr(domaene[1].server_id) | ipaddr('address') }};
 		};
+		dnssl "{{freifunk.search_domain}}";
 	};
 {% endfor %}
 };
 {% endif %}
 
+filter subnetv6 {
+{% if domaenenliste is defined %}
+{% for domaene in domaenenliste|dictsort %}
+	if net = {{domaenen[domaene[0]].ffv6_network}} then accept;
+{% endfor %}
+{% endif %}
+	reject;
+};
 
 protocol bfd {
 	table ffnet;
@@ -53,10 +66,43 @@ protocol device {
 	scan time 10;
 };
 
-protocol ospf {
+{% if ipv6_direkt_ausleiten is defined and ipv6_direkt_ausleiten %}
+protocol static v6localexit {
+        table ffnet;
+        preference 1000;
+        route ::/0 via {{ ansible_default_ipv6.gateway }};
+};
+{% endif %}
+
+{% if ipv6_direkt_ausleiten is defined and ipv6_direkt_ausleiten %}
+protocol ospf upstream {
+	table ffnet;
+	import where is_default();
+	export filter subnetv6;
+{% if ospf_nat_instanceid is defined %}
+	instance id {{ospf_nat_instanceid}};
+{% endif %}
+
+{% if ospf_nat_area is defined %}
+	area {{ospf_nat_area}} {
+{% else %}
+	area 0.0.0.0 {
+{% endif %}
+	    interface "{{ansible_default_ipv4.interface}}" {
+                cost 10;
+{% if ospf_nat_options is defined %}
+            	{{ospf_nat_options}}
+{% endif %}
+	    };
+	};
+};
+{% endif %}
+
+protocol ospf backbone {
 	table ffnet;
 	import filter freifunk;
 	export all;
+
 	area 0.0.0.0 {
 		interface "bat*" {
 			stub;
@@ -69,16 +115,13 @@ protocol ospf {
 {% endif %}
 {% endfor %}
 		interface "bck-*";
+
 {% if ffrl_tun is defined %}
 		interface "lo" {
 			stub;
 		};
 {% endif %}
 	};
-};
-
-function is_default() {
-	return (net ~ [::/0]);
 };
 
 filter export_to_upstream_filter {
@@ -91,6 +134,7 @@ protocol static static_Gesamtnetzwerk {
 	route {{ff_network.v6_network}} reject;
 };
 
+{% if ffrl_tun is defined or ffnw_tun is defined %}
 {% if domaenenliste is defined %}
 {% for domaene in domaenenliste|dictsort %}
 protocol static static_domaene{{domaene[0]}} {
@@ -98,6 +142,7 @@ protocol static static_domaene{{domaene[0]}} {
 	route {{domaenen[domaene[0]].ffv6_network | regex_replace('..::/\d+$','00::/56')}} reject;
 };
 {% endfor %}
+{% endif %}
 {% endif %}
 {% if dhcp is defined %}
 protocol static 'static_{{inventory_hostname_short}}' {

--- a/gateways_gre_upstream/tasks/main.yml
+++ b/gateways_gre_upstream/tasks/main.yml
@@ -19,5 +19,5 @@
   template: src="gre_upstream.j2" dest="/etc/network/interfaces.d/40_gre_upstream.cfg"
   notify:
     - restart networking
-  when: ffrl_tun is defined or ffnw_tun is defined
+  when: ffrl_tun is defined or ffnw_tun is defined or ffgt_tun is defined
 

--- a/gateways_gre_upstream/templates/gre_upstream.j2
+++ b/gateways_gre_upstream/templates/gre_upstream.j2
@@ -39,3 +39,24 @@ iface tun-ffnw-{{tun.name}} inet6 static
         pre-down ip -6 rule del iif $IFACE lookup ffnet ||:
 {% endfor %}
 {% endif %}
+
+{% if ffgt_tun is defined %}
+{% for tun in ffgt_tun %}
+
+auto tun-ffgt-{{tun.name}}
+iface tun-ffgt-{{tun.name}} inet static
+        address {{tun.v4_local | ipaddr('address')}}
+        netmask {{tun.v4_local | ipaddr('netmask')}}
+        pre-up ip tunnel add $IFACE mode gre local {{tun.gre_source | ipaddr('address') }} remote {{tun.gre_target | ipaddr('address') }} ttl 255
+        post-up ip link set $IFACE mtu 1400
+        post-down ip tunnel del $IFACE
+        post-up ip rule add iif $IFACE lookup ffnet
+        pre-down ip rule del iif $IFACE lookup ffnet ||:
+iface tun-ffnw-{{tun.name}} inet6 static
+        address {{tun.v6_local }}
+        netmask {{tun.v6_remote | ipaddr('prefix')}}
+        post-up ip -6 rule add iif $IFACE lookup ffnet
+        pre-down ip -6 rule del iif $IFACE lookup ffnet ||:
+{% endfor %}
+{% endif %}
+

--- a/gateways_gre_upstream/templates/lo.j2
+++ b/gateways_gre_upstream/templates/lo.j2
@@ -12,9 +12,20 @@ iface lo inet loopback
         up ip rule add from {{ ffnw_nat_ip }} table ffnet
         up ip rule add iif lo table ffnet suppress_prefixlength 0
         up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
+{% elif ffgt_tun is defined and ffgt_nat_ip is defined %}
+        up ip address add {{ ffgt_nat_ip }} dev lo
+        up ip rule add from {{ ffgt_nat_ip }} table ffnet
+        up ip rule add iif lo table ffnet suppress_prefixlength 0
+        up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
+{% elif ospf_nat_ip is defined %}
+        up ip address add {{ ospf_nat_ip }} dev lo
+        up ip rule add from {{ ospf_nat_ip }} table ffnet
+        up ip rule add iif lo table ffnet suppress_prefixlength 0
+        up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
 {% else %}
         up ip address add 10.0.0.{{vm_id}} dev lo
         up ip rule add from 10.0.0.{{vm_id}} table ffnet
         up ip rule add iif lo table ffnet suppress_prefixlength 0
         up ip -6 rule add iif lo table ffnet suppress_prefixlength 0
 {% endif %}
+

--- a/iptables/templates/rules.v4.j2
+++ b/iptables/templates/rules.v4.j2
@@ -13,25 +13,19 @@ COMMIT
 :OUTPUT ACCEPT [0:0]
 :POSTROUTING ACCEPT [0:0]
 {% if ipv4_direkt_ausleiten is defined and ipv4_direkt_ausleiten %}
-{% if domaenenliste is defined %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -j SNAT --to-source {{ansible_default_ipv4.address}}
+{% elif ospf_nat_ip is defined %}
 {% for domaene in domaenenliste|dictsort %}
--A POSTROUTING -o {{ ansible_default_ipv4.interface }} --source {{ domaenen[domaene[0]].ffv4_network }} -j SNAT --to-source {{ ansible_default_ipv4.address }}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -j SNAT -s {{domaenen[domaene[0]].ffv4_network}} --to-source {{ospf_nat_ip | ipaddr('address')}}
 {% endfor %}
-{% endif %}
 {% elif ffrl_tun is defined and ffrl_nat_ip is defined %}
-{% if domaenenliste is defined %}
-{% for domaene in domaenenliste|dictsort %}
--A POSTROUTING -o tun-ffrl+ --source {{ domaenen[domaene[0]].ffv4_network }} -j SNAT --to-source {{ ffrl_nat_ip | ipaddr('address') }}
-{% endfor %}
-{% endif %}
+-A POSTROUTING -o tun-ffrl+ -j SNAT --to-source {{ffrl_nat_ip | ipaddr('address')}}
 {% elif ffnw_tun is defined and ffnw_nat_ip is defined %}
-{% if domaenenliste is defined %}
-{% for domaene in domaenenliste|dictsort %}
--A POSTROUTING -o tun-ffnw+ --source {{ domaenen[domaene[0]].ffv4_network }} -j SNAT --to-source {{ ffnw_nat_ip | ipaddr('address') }}
-{% endfor %}
+-A POSTROUTING -o tun-ffnw+ -j SNAT --to-source {{ffnw_nat_ip| ipaddr('address')}}
+{% elif ffgt_tun is defined and ffgt_nat_ip is defined %}
+-A POSTROUTING -o tun-ffgt+ -j SNAT --to-source {{ffgt_nat_ip| ipaddr('address')}}
 {% endif %}
-{% endif %}
-{% if ffnw_tun is not defined and ffnw_nat_ip is not defined and ffrl_tun is not defined and ffrl_nat_ip is not defined %}
+{% if ffnw_tun is not defined and ffnw_nat_ip is not defined and ffrl_tun is not defined and ffrl_nat_ip is not defined and ffgt_tun is not defined and ffgt_nat_ip is not defined %}
 -A POSTROUTING -o gre+ -p tcp -m tcp --dport 53 -j SNAT --to-source 10.0.0.{{vm_id}}
 -A POSTROUTING -o gre+ -p udp -m udp --dport 53 -j SNAT --to-source 10.0.0.{{vm_id}}
 {% endif %}
@@ -41,8 +35,30 @@ COMMIT
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
+-N DNS
+-A OUTPUT -p udp -m udp --dport 53 -j DNS
+-A OUTPUT -p tcp -m tcp --dport 53 -j DNS
+{% if 'dienste' in groups %}
+{% for host in groups['dienste'] %}
+{% if hostvars[host].inventory_hostname_short == "dnsmaster" %}
+-A DNS -d {{hostvars[host].ansible_ssh_host}}/32 -j RETURN
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if v4dnsips is defined %}
+{% for entry in v4dnsips %}
+-A DNS -d {{entry}}/32 -j RETURN
+{% endfor %}
+{% endif %}
+-A DNS -j MARK --set-mark 0x1
+-A DNS -j RETURN
 :POSTROUTING ACCEPT [0:0]
-{% if ffrl_tun is defined or ffnw_tun is defined %}
+{% if ffrl_tun is defined or ffnw_tun is defined or ffgt_tun is defined %}
 -A POSTROUTING -o tun-+ -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
+{% elif ospf_nat_ip is defined %}
+{% for domaene in domaenenliste|dictsort %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -s {{domaenen[domaene[0]].ffv4_network}} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
+{% endfor %}
+-A POSTROUTING -o {{ansible_default_ipv4.interface}} -s {{ospf_nat_ip | ipaddr('address')}} -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1240 -j TCPMSS --set-mss 1240
 {% endif %}
 COMMIT

--- a/iptables/templates/rules.v6.j2
+++ b/iptables/templates/rules.v6.j2
@@ -10,8 +10,16 @@ COMMIT
 :INPUT ACCEPT [0:0]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [0:0]
+-N DNS 
+-A INPUT -p udp -m udp --dport 53 -j DNS 
+-A INPUT -p tcp -m tcp --dport 53 -j DNS 
+{% if v6dnsips is defined %}
+{% for entry in v6dnsips %}
+-A DNS -d {{entry}}/32 -j RETURN
+{% endfor %}
+{% endif %}
 :POSTROUTING ACCEPT [0:0]
-{% if ffrl_tun is defined %}
+{% if ffrl_tun is defined or ffgt_tun is defined %}
 -A POSTROUTING -o tun-+ -p tcp -m tcp --tcp-flags SYN,RST SYN -m tcpmss ! --mss 0:1220 -j TCPMSS --set-mss 1220
 {% endif %}
 COMMIT


### PR DESCRIPTION
- bird4 & bird6 files structured similarily
- allow for FFGT tunnels (in addition to FFRL, FFNW); GRE-only for now (FFGT prefers L2TP)
- allow for ospf_nat_ip, i. e. use a NAT IP that's distribution within one's AS via OSPF
- fix ipv6_direkt_ausleiten
- drop dhcp pool network breakdown and announcement (for now, announce 240.255.255.255/32 instead — Class E)
