### PR TITLE
Ersetze server_id durch vm_id

### DIFF
--- a/collectd/templates/collectd.conf.j2
+++ b/collectd/templates/collectd.conf.j2
@@ -636,7 +636,7 @@ LoadPlugin write_graphite
 {% if "domaenenliste" in hostvars[host] %}
 	Host "{{domaenen[domaene[0]].ffv4_network | ipaddr(hostvars[host].domaenenliste[domaene[0]].server_id) | ipaddr('address') }}"
 {% else %}
-	Host "{{domaenen[domaene[0]].ffv4_network | ipaddr(hostvars[host].server_id) | ipaddr('address') }}"
+	Host "{{domaenen[domaene[0]].ffv4_network | ipaddr(hostvars[host].vm_id) | ipaddr('address') }}"
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/dhcp/templates/dhcpd.conf.j2
+++ b/dhcp/templates/dhcpd.conf.j2
@@ -10,8 +10,8 @@ log-facility local7;
 subnet {{ff_network.v4_network | ipaddr('network')}} netmask {{ff_network.v4_network | ipaddr('netmask')}} {
     range {{dhcp.range_start}} {{dhcp.range_end}};
 
-    option routers {{ff_network.v4_network | ipaddr(server_id) | ipaddr('address') }};
-    option domain-name-servers {{ff_network.v4_network | ipaddr(server_id) | ipaddr('address') }};
+    option routers {{ff_network.v4_network | ipaddr(vm_id) | ipaddr('address') }};
+    option domain-name-servers {{ff_network.v4_network | ipaddr(vm_id) | ipaddr('address') }};
     option interface-mtu {{dhcp_global.mtu}};
 }
 {% if "static_hosts" in hostvars[inventory_hostname] %}

--- a/dhcp/templates/dhcpd6.conf.j2
+++ b/dhcp/templates/dhcpd6.conf.j2
@@ -2,7 +2,7 @@
 allow leasequery;
 
 # Global definitions for name server address(es)
-option dhcp6.name-servers {{ff_network.v6_network | ipaddr(server_id) | ipaddr('address')}};
+option dhcp6.name-servers {{ff_network.v6_network | ipaddr(vm_id) | ipaddr('address')}};
 
   subnet6 {{ff_network.v6_network}} {
 }

--- a/mapserver_interfaces/templates/batman.j2
+++ b/mapserver_interfaces/templates/batman.j2
@@ -8,11 +8,11 @@
 # BATMAN Interface für Domäne-{{domaene[0]}}
 auto bat{{domaene[0]}}
 iface bat{{domaene[0]}} inet6 static
-        address fe80::dcad:beff:feef:{{ '%02x' % indexer[0] }}{{'%02d' % server_id}}
+        address fe80::dcad:beff:feef:{{ '%02x' % indexer[0] }}{{'%02d' % vm_id}}
         netmask 64
         pre-up modprobe batman-adv
         pre-up ip link add bat{{domaene[0]}} type batadv
-        post-up ip link set address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{server_id}} dev bat{{domaene[0]}}
+        post-up ip link set address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{vm_id}} dev bat{{domaene[0]}}
         post-up ip link set dev bat{{domaene[0]}} up
         post-up batctl -m bat{{domaene[0]}} it 10000
 {% for host in groups["gateways"] %}
@@ -21,10 +21,10 @@ iface bat{{domaene[0]}} inet6 static
 {% endif %}
 {% endfor %}
         post-up batctl -m bat{{domaene[0]}} mm 0
-        post-up ip -6 addr add {{domaene[1].ffv6_network | ipaddr(server_id) | ipaddr('address')}}/64 dev bat{{domaene[0]}}
+        post-up ip -6 addr add {{domaene[1].ffv6_network | ipaddr(vm_id) | ipaddr('address')}}/64 dev bat{{domaene[0]}}
 
 iface bat{{domaene[0]}} inet static
-        address {{domaene[1].ffv4_network | ipaddr(server_id) | ipaddr('address') }}
+        address {{domaene[1].ffv4_network | ipaddr(vm_id) | ipaddr('address') }}
         netmask {{domaene[1].ffv4_network | ipaddr('netmask')}}
         post-down ip link del bat{{domaene[0]}}
 
@@ -39,7 +39,7 @@ iface t{{domaene[0]}}-{{ host }} inet manual
 {% else %}
         pre-up ip link add $IFACE type gretap local {{ansible_default_ipv4.address}} remote {{hostvars[host].ipv4}} dev {{ansible_default_ipv4.interface}} key {{domaene[0]|int}}
 {% endif %}
-        pre-up ip link set dev $IFACE address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{server_id}}
+        pre-up ip link set dev $IFACE address de:ad:be:ef:{{ '%02x' % indexer[0] }}:{{vm_id}}
         pre-up ip link set $IFACE up
         post-up batctl -m bat{{domaene[0]}} if add $IFACE ||:
         pre-down batctl -m bat{{domaene[0]}} if del $IFACE ||:

--- a/motd/templates/99-custom.j2
+++ b/motd/templates/99-custom.j2
@@ -31,7 +31,7 @@ cat << 'EOF'
  Domäne-{{domaene[0]}}   : {{domaenen[domaene[0]].ffv4_network | ipaddr(domaene[1].server_id) | ipaddr('address') }} / {{domaenen[domaene[0]].ffv6_network | ipaddr(domaene[1].server_id) | ipaddr('address') }}
 {% endfor %}
 {% elif group_names[0].startswith('domaene-') %}
- Freifunk IP:     {{ff_network.v4_network | ipaddr(server_id) | ipaddr('address') }} / {{ff_network.v6_network | ipaddr(server_id) | ipaddr('address') }}
+ Freifunk IP:     {{ff_network.v4_network | ipaddr(vm_id) | ipaddr('address') }} / {{ff_network.v6_network | ipaddr(vm_id) | ipaddr('address') }}
 
  Domäne: {{ group_names | last }}
 {% else %}

--- a/nrpe/templates/check_batip.j2
+++ b/nrpe/templates/check_batip.j2
@@ -10,8 +10,8 @@ STATE_UNKNOWN=3
 # Pro Domäne max. sechs Server pingen, falls mehr als die Hälfte nicht pingbar ? Wahrscheinlich hängt das Batman 
 #########################################################################
 
-MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'server_id') | join(" ") }}"
-GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'server_id') | join(" ") }}"
+MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'vm_id') | join(" ") }}"
+GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'vm_id') | join(" ") }}"
 CHECKIP="$MAPSERVER $GATEWAYS"
 
 COUNTREQUIRED=$(($(echo $CHECKIP | wc -w)/2))

--- a/nrpe/templates/check_batip6.j2
+++ b/nrpe/templates/check_batip6.j2
@@ -12,8 +12,8 @@ STATE_UNKNOWN=3
 # iPV6
 #########################################################################
 
-MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'server_id') | join(" ") }}"
-GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'server_id') | join(" ") }}"
+MAPSERVER="{{ (groups['mapserver'] | default([]))[:2] | map('extract',hostvars,'vm_id') | join(" ") }}"
+GATEWAYS="{{ (groups['gateways'] | default([]))[:4] | map('extract',hostvars,'vm_id') | join(" ") }}"
 CHECKIP="$MAPSERVER $GATEWAYS"
 
 COUNTREQUIRED=$(($(echo $CHECKIP | wc -w)/2))


### PR DESCRIPTION
Die Angabe von "server_id" im Inventory ist nicht mehr nötig.
Siehe https://forum.freifunk-muensterland.de/t/fragen-zu-ansible-variablen-hostname-suffix-und-server-id-vm-id/4398