### PR TITLE
common: Log-Aufbewahrungsdauer von journald an die von logrotate anpassen

### DIFF
--- a/common/tasks/main.yml
+++ b/common/tasks/main.yml
@@ -100,7 +100,7 @@
   lineinfile:
     dest: /etc/systemd/journald.conf
     regexp: "^[#]?MaxRetentionSec"
-    line: "MaxRetentionSec={{ logrotate.count }}week"
+    line: "MaxRetentionSec={{ logrotate.cycle | lower | replace('daily',1) | replace('weekly',7) | replace('monthly',30) | replace('yearly',365) | int * logrotate.count | int }}day"
   when: journald_conf.stat.exists
   notify: restart journald
 


### PR DESCRIPTION
Aus den Logrotate-Variablen "logrotate.count" und "logrotate.cycles" wird die Anzahl an Tagen
berechnet, die die journald-Logs aufgehoben werden sollen.