### PR TITLE
motd: Mache Variable "server_besitzer" optional

### DIFF
--- a/motd/templates/99-custom.j2
+++ b/motd/templates/99-custom.j2
@@ -15,7 +15,9 @@ echo " IP address  : $(hostname -I | cut -d' ' -f1){% if ansible_default_ipv6.ad
 echo " System type : $(uname -s) $(uname -m)"
 echo " Kernel      : $(uname -r)"
 echo " "
+{% if server_besitzer is defined %}
 echo " Besitzer    : {{ server_besitzer }}"
+{% endif %}
 
 cat << 'EOF'
 


### PR DESCRIPTION
Die Rollen motd und py_respondd sind die einzigen, die die Variable "server_besitzer" benutzen.
Für motd ist sie nicht essentiell und sollte deswegen dort auch nicht zwingend erforderlich sein.