### PR TITLE
icinga2-server: Fix und Verbesserungen

### DIFF
--- a/icinga2-server/README.md
+++ b/icinga2-server/README.md
@@ -13,10 +13,18 @@ Die Konfiguration erfolgt durch Variable "icinga2":
         - user: username2
           pw: passwort2
         - email: beispiel@bar.baz
+      api_listener:
+        address: "192.168.5.2"
+        port: "5000"
+      http_listener:
+        address: "192.168.102.69"
+        port: "81"
 ```
-- **api:** Icinga2-API ein- (=true) oder ausschalten (=false). Standard: false. Über die API ist nur Monitoring erlaubt, kein Anlegen/Ändern/Löschen von Objekten u.ä.
-- **icingaweb2:** IcingaWeb2-Weboberfläche ein- (=true) oder ausschalten (=false). Standard: false
+- **api:** Icinga2-API ein- (=true) oder ausschalten (=false). Wenn nicht gesetzt wird "false" angenommen. Über die API ist nur Monitoring erlaubt, kein Anlegen/Ändern/Löschen von Objekten u.ä..
+- **icingaweb2:** IcingaWeb2-Weboberfläche ein- (=true) oder ausschalten (=false).
 - **userliste:** Enthält eine Liste mit Benutzern. Ein Benutzer muss Benutzername und Passwort und/oder E-Mailadresse haben.
+- **api_lister:**  Ändert die IP-Adresse und den Ports für Icinga2-API. Wenn nicht gesetzt wird als "address" "::" und als "port" "5665" verwendet, womit die Icinga2-API an alle Netzwerkschnittstellen auf Port 5665 verfügbar ist.
+- **http_listener:** Ändern die IP-Adresse und den Ports für IcingaWeb2. Wenn nicht gesetzt wird als "address" "*" und als "port" "80" verwendet, womit IcingaWeb2 an alle Netzwerkschnittstellen auf Port 80 verfügbar ist.
 
 Falls die Icinga2-API und/oder IcingaWeb2 eingeschaltet ist, dann haben alle in "userliste" mit Benutzername ("user") und Passwort ("pw") angebenen Benutzer darauf Zugriff.
 An alle in "userliste" angegebenen E-Mail-Adressen ("email") versendet Icinga2 Notifications. Dazu ist die Rolle exim4-daemon-light nötig, die die E-Mails lokal annimmt und an einen SMTP-Server weiterleitet.
@@ -24,8 +32,9 @@ An alle in "userliste" angegebenen E-Mail-Adressen ("email") versendet Icinga2 N
 Im Beispiel oben gibt es drei User: Zwei davon können sich an der API und an IcingaWeb2 anmelden, einer davon bekommt die Alerts zusätzlich per E-Mail. Der dritte User kann sich nirgends anmelden und wird nur per E-Mail über Alerts informiert.
 
 
-Auf die API kann über https, Port 5665, zugegriffen werden. Das von Icinga2 dafür erzeugte CA-Zertifikat wird auf dem Ansible-Controller unter "keyfiles/icinga2/HOSTNAME-ca.crt" abgelegt.
-Auf IcingaWeb2 kann über Port 80 zugegriffen werden.
+Auf die API kann, wenn nicht anders konfiguriert, über https, Port 5665, zugegriffen werden.
+Das von Icinga2 dafür erzeugte CA-Zertifikat wird auf dem Ansible-Controller unter "keyfiles/icinga2/HOSTNAME-ca.crt" abgelegt.
+Auf IcingaWeb2 kann, wenn nicht anders konfiguriert, über http, Port 80, zugegriffen werden.
 
 ### Kompatibilität:
 Derzeit nur Debian 10

--- a/icinga2-server/README.md
+++ b/icinga2-server/README.md
@@ -23,3 +23,9 @@ An alle in "userliste" angegebenen E-Mail-Adressen ("email") versendet Icinga2 N
 
 Im Beispiel oben gibt es drei User: Zwei davon können sich an der API und an IcingaWeb2 anmelden, einer davon bekommt die Alerts zusätzlich per E-Mail. Der dritte User kann sich nirgends anmelden und wird nur per E-Mail über Alerts informiert.
 
+
+Auf die API kann über https, Port 5665, zugegriffen werden. Das von Icinga2 dafür erzeugte CA-Zertifikat wird auf dem Ansible-Controller unter "keyfiles/icinga2/HOSTNAME-ca.crt" abgelegt.
+Auf IcingaWeb2 kann über Port 80 zugegriffen werden.
+
+### Kompatibilität:
+Derzeit nur Debian 10

--- a/icinga2-server/files/apache2-icingaweb2-local.conf
+++ b/icinga2-server/files/apache2-icingaweb2-local.conf
@@ -7,10 +7,6 @@ RedirectMatch ^/$ /icingaweb2
     AuthName "Icingaweb2"
     AuthUserFile /etc/icingaweb2/.http-users
 
-    <Files *.php>
-        php_value date.timezone "Europe/Berlin"
-    </Files>
-
     <RequireAny>
         require valid-user
     </RequireAny>

--- a/icinga2-server/files/icingaweb2/authentication.ini
+++ b/icinga2-server/files/icingaweb2/authentication.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [icingaweb2]
 strip_username_regexp = ""

--- a/icinga2-server/files/icingaweb2/config.ini
+++ b/icinga2-server/files/icingaweb2/config.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [global]
 show_stacktraces = "1"

--- a/icinga2-server/files/icingaweb2/modules/graphite/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/graphite/config.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [graphite]
 url = "http://localhost:8180"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/backends.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/backends.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [icinga]
 type = "ido"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/commandtransports.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/commandtransports.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [icinga2]
 transport = "local"

--- a/icinga2-server/files/icingaweb2/modules/monitoring/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/monitoring/config.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [security]
 protected_customvars = "*pw*,*pass*,community"

--- a/icinga2-server/files/icingaweb2/modules/translation/config.ini
+++ b/icinga2-server/files/icingaweb2/modules/translation/config.ini
@@ -1,4 +1,4 @@
-# Ansible managed
+; Ansible managed
 
 [translation]
 msgmerge = /usr/bin/msgmerge

--- a/icinga2-server/handlers/main.yml
+++ b/icinga2-server/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
 
-- name: restart icinga2
+- name: reload icinga2
   service:
     name: icinga2
-    state: restarted
+    state: reloaded
 
 - name: reload apache2
   service:

--- a/icinga2-server/tasks/icinga2-api.yml
+++ b/icinga2-server/tasks/icinga2-api.yml
@@ -1,10 +1,4 @@
 ### API-Module
-- name: Configure hostname for certificates
-  lineinfile:
-    dest: /etc/icinga2/constants.conf
-    regexp: '^const NodeName\s*='
-    line: 'const NodeName = "{{ ansible_hostname }}"'
-  notify: restart icinga2
 
 - name: Create Icinga2 API CA directories
   file:
@@ -28,18 +22,22 @@
 
 - name: Generate CSR
   command:
-    cmd: icinga2 pki new-cert \
-      --cn {{ ansible_hostname }} --key /var/lib/icinga2/certs/{{ ansible_hostname }}.key --csr /var/lib/icinga2/certs/{{ ansible_hostname }}.csr
+    cmd: icinga2 pki new-cert
+      --cn {{ inventory_hostname_short }}.{{ freifunk.domain }}
+      --key /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.key
+      --csr /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.csr
     creates: '{{ item.creates }}'
   loop:
-    - creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.key'
-    - creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.csr'
+    - creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.key'
+    - creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.csr'
   notify: restart icinga2
 
 - name: Sign CSR and create certifiate
   command:
-    cmd: icinga2 pki sign-csr --csr /var/lib/icinga2/certs/{{ ansible_hostname }}.csr --cert /var/lib/icinga2/certs/{{ ansible_hostname }}.crt
-    creates: '/var/lib/icinga2/certs/{{ ansible_hostname }}.crt'
+    cmd: icinga2 pki sign-csr
+      --csr /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.csr
+      --cert /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.crt
+    creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.crt'
   notify: restart icinga2
 
 - name: Copy CA certificate
@@ -49,9 +47,14 @@
     dest: '/var/lib/icinga2/certs/ca.crt'
   notify: restart icinga2
 
+- name: Store CA certificate in keyfiles
+  fetch:
+    src: '/var/lib/icinga2/ca/ca.crt'
+    dest: 'keyfiles/icinga2/{{ inventory_hostname }}-ca.crt'
+    flat: yes
+
 - name: Enable Icinga2 API module
-  file:
-    src: '../features-available/api.conf'
+  template:
+    src: 'icinga2/features/api/api.conf.j2'
     dest: '/etc/icinga2/features-enabled/api.conf'
-    state: link
   notify: restart icinga2

--- a/icinga2-server/tasks/icinga2-api.yml
+++ b/icinga2-server/tasks/icinga2-api.yml
@@ -18,7 +18,7 @@
   loop:
     - creates: '/var/lib/icinga2/ca/ca.key'
     - creates: '/var/lib/icinga2/ca/ca.crt'
-  notify: restart icinga2
+  notify: reload icinga2
 
 - name: Generate CSR
   command:
@@ -30,7 +30,7 @@
   loop:
     - creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.key'
     - creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.csr'
-  notify: restart icinga2
+  notify: reload icinga2
 
 - name: Sign CSR and create certifiate
   command:
@@ -38,14 +38,14 @@
       --csr /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.csr
       --cert /var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.crt
     creates: '/var/lib/icinga2/certs/{{ inventory_hostname_short }}.{{ freifunk.domain }}.crt'
-  notify: restart icinga2
+  notify: reload icinga2
 
 - name: Copy CA certificate
   copy:
     remote_src: yes
     src: '/var/lib/icinga2/ca/ca.crt'
     dest: '/var/lib/icinga2/certs/ca.crt'
-  notify: restart icinga2
+  notify: reload icinga2
 
 - name: Store CA certificate in keyfiles
   fetch:
@@ -57,4 +57,4 @@
   template:
     src: 'icinga2/features/api/api.conf.j2'
     dest: '/etc/icinga2/features-enabled/api.conf'
-  notify: restart icinga2
+  notify: reload icinga2

--- a/icinga2-server/tasks/icinga2.yml
+++ b/icinga2-server/tasks/icinga2.yml
@@ -71,8 +71,8 @@
   notify: restart icinga2
   tags: skip_ansible_lint
 
-### Config Files
-- name: Clean default config files
+### Configuration
+- name: Delete unneeded default config files
   file:
     state: absent
     path: "/etc/icinga2/conf.d/{{ item }}"
@@ -84,7 +84,13 @@
     - "services.conf"
   notify: reload icinga2
 
-- name: Create base configuration
+- name: Create base configuration in /etc/icinga2/
+  template:
+    src: "icinga2/constants.conf.j2"
+    dest: "/etc/icinga2/constants.conf"
+  notify: reload icinga2
+
+- name: Create base configuration in /etc/icinga2/conf.d/
   template:
     src: "{{ item.src }}"
     dest: "/etc/icinga2/conf.d/{{ item.path|regex_replace('.j2','') }}"

--- a/icinga2-server/tasks/icinga2.yml
+++ b/icinga2-server/tasks/icinga2.yml
@@ -6,7 +6,7 @@
 ### Icinga2
 - name: Install Icinga2
   apt:
-    pkg: [ 'icingacli', 'icinga2', 'monitoring-plugins-basic', 'nagios-nrpe-plugin' ]
+    pkg: [ 'icingacli', 'icinga2', 'monitoring-plugins-basic', 'nagios-nrpe-plugin', 'bsd-mailx' ]
     state: present
 
 ### Command-Module
@@ -15,7 +15,7 @@
     src: '../features-available/command.conf'
     dest: '/etc/icinga2/features-enabled/command.conf'
     state: link
-  notify: restart icinga2
+  notify: reload icinga2
 
 ### IDO-Module
 - name: Install MariaDB and Icinga2 IDO modules
@@ -36,7 +36,7 @@
     group: 'nagios'
     mode: '0600'
   when: not icinga2_ido_db_conf.stat.exists
-  notify: restart icinga2
+  notify: reload icinga2
 
 - name: Read ido-mysql.conf
   slurp:
@@ -60,6 +60,7 @@
     password: '{{ icinga2_ido_db_pw }}'
     host: localhost
     priv: 'icinga2_ido.*:ALL'
+  no_log: true
 
 - name: Import IDO database schema
   mysql_db:
@@ -68,7 +69,7 @@
     state: import
     target: '/usr/share/icinga2-ido-mysql/schema/mysql.sql'
   when: icinga2_ido_db.changed
-  notify: restart icinga2
+  notify: reload icinga2
   tags: skip_ansible_lint
 
 ### Configuration

--- a/icinga2-server/tasks/icingaweb2.yml
+++ b/icinga2-server/tasks/icingaweb2.yml
@@ -3,9 +3,10 @@
   apt:
     pkg: [ 'python3-passlib' ]
 
+### IcingaWeb2
 - name: Install IcingaWeb2
   apt:
-    pkg: [ 'icingaweb2', 'apache2' ]
+    pkg: [ 'icingaweb2', 'apache2', 'php-mysql', 'php-curl', 'php-gd', 'php-imagick', 'php-intl', 'php-fpm' ]
     state: present
 
 ### IDO
@@ -55,6 +56,32 @@
     mode: '0660'
     directory_mode: '2770'
 
+## Enable Apache PHP-FPM
+- name: Enable required Apache modules
+  apache2_module:
+    name: '{{ item }}'
+    state: present
+  loop:
+    - proxy_fcgi
+    - setenvif
+  notify: reload apache2
+
+- name: Figure out PHP-FPM Apache configuration file
+  find:
+    paths: '/etc/apache2/conf-available/'
+    file_type: file
+    use_regex: yes
+    patterns: '^php[0-9\.]+\-fpm\.conf'
+  register: find_phpfpmconf
+
+- name: Enable PHP-FPM Apache configuration file
+  file:
+    src: '/etc/apache2/conf-available/{{ item.path | basename }}'
+    dest: '/etc/apache2/conf-enabled/{{ item.path | basename }}'
+    state: link
+  loop: '{{ find_phpfpmconf.files }}'
+  notify: reload apache2
+
 ### Enable IcingaWeb2 in Apache
 - name: Enable IcingaWeb2 in Apache
   file:
@@ -72,6 +99,11 @@
     group: 'root'
     mode: '0644'
   notify: reload apache2
+
+- name: Delete old htpasswd file to force password updates and to get rid of deprecated users
+  file:
+    path: '/etc/icingaweb2/.http-users'
+    state: absent
 
 - name: Create htpasswd file
   htpasswd:

--- a/icinga2-server/tasks/icingaweb2.yml
+++ b/icinga2-server/tasks/icingaweb2.yml
@@ -90,7 +90,7 @@
     state: link
   notify: reload apache2
 
-### Authentication
+### Set up Apache Authentication
 - name: Configure basic authentication in Apache
   copy:
     src: 'apache2-icingaweb2-local.conf'
@@ -123,6 +123,29 @@
     owner: 'www-data'
     group: 'icingaweb2'
     mode: '0640'
+
+### Set Apache HTTP listening port and address
+- name: Set Apache2 listening ports
+  template:
+    src: "apache2/ports.conf.j2"
+    dest: "/etc/apache2/ports.conf"
+  notify: reload apache2
+
+- name: Get all enabled non-SSL Apache2 sites
+  shell: "/usr/bin/grep -Li '^[[:space:]]*SSL' /etc/apache2/sites-enabled/*"
+  register: httpsitesenabled
+  failed_when: "httpsitesenabled.rc == 2"
+  check_mode: no
+  changed_when: httpsitesenabled.stdout | length > 0
+
+- name: Set HTTP listening ports in all enabled non-SSL Apache2 sites
+  lineinfile:
+    path: "{{ item }}"
+    regexp: '(?i)<VirtualHost (.+?):(\d+)>'
+    line: "<VirtualHost {{ icinga2.http_listener.address | default('*') }}:{{ icinga2.http_listener.port | default(80) }}>"
+    backrefs: yes
+  with_items: "{{ httpsitesenabled.stdout_lines }}"
+  when: httpsitesenabled.stdout | length > 0
 
 ### Logging
 - name: Configure logging

--- a/icinga2-server/tasks/main.yml
+++ b/icinga2-server/tasks/main.yml
@@ -12,7 +12,7 @@
   file:
     path: '/etc/icinga2/features-enabled/api.conf'
     state: absent
-  notify: restart icinga2
+  notify: reload icinga2
 
 - import_tasks: icingaweb2.yml
   when: icinga2.icingaweb2 is defined and icinga2.icingaweb2

--- a/icinga2-server/templates/apache2/ports.conf.j2
+++ b/icinga2-server/templates/apache2/ports.conf.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+
+Listen {{ icinga2.http_listener.address | default("*") }}:{{ icinga2.http_listener.port | default(80) }} http
+
+#<IfModule ssl_module>
+#       Listen {{ icinga2.https_listener.address | default("*") }}:{{ icinga2.https_listener.port | default(443) }} https
+#</IfModule>
+#
+#<IfModule mod_gnutls.c>
+#       Listen {{ icinga2.https_listener.address | default("*") }}:{{ icinga2.https_listener.port | default(443) }} https
+#</IfModule>

--- a/icinga2-server/templates/icinga2/conf.d/api-users.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/api-users.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 /**
  * The ApiUser objects are used for authentication against the API.

--- a/icinga2-server/templates/icinga2/conf.d/app.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/app.conf.j2
@@ -1,3 +1,3 @@
-# {{ ansible_managed }}
+/*  {{ ansible_managed }} */
 
 object IcingaApplication "app" { }

--- a/icinga2-server/templates/icinga2/conf.d/command-nrpe2.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/command-nrpe2.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/*  {{ ansible_managed }} */
 
 object CheckCommand "nrpe2" {
     import "ipv4-or-ipv6"

--- a/icinga2-server/templates/icinga2/conf.d/commands.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/commands.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/*  {{ ansible_managed }} */
 
 /* Command objects */
 

--- a/icinga2-server/templates/icinga2/conf.d/notifications.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/notifications.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 /**
  * The example notification apply rules.

--- a/icinga2-server/templates/icinga2/conf.d/templates.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/templates.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 /*
  * Generic template examples.

--- a/icinga2-server/templates/icinga2/conf.d/timeperiods.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/timeperiods.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 /**
  * Sample timeperiods for Icinga 2.

--- a/icinga2-server/templates/icinga2/conf.d/users.conf.j2
+++ b/icinga2-server/templates/icinga2/conf.d/users.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 object UserGroup "freifunk_admins" {
   display_name = "Freifunk-Adminstratoren"

--- a/icinga2-server/templates/icinga2/constants.conf.j2
+++ b/icinga2-server/templates/icinga2/constants.conf.j2
@@ -1,0 +1,32 @@
+/* {{ ansible_managed }} */
+
+/**
+ * This file defines global constants which can be used in
+ * the other configuration files.
+ */
+
+/* The directory which contains the plugins from the Monitoring Plugins project. */
+const PluginDir = "/usr/lib/nagios/plugins"
+
+/* The directory which contains the Manubulon plugins.
+ * Check the documentation, chapter "SNMP Manubulon Plugin Check Commands", for details.
+ */
+const ManubulonPluginDir = "/usr/lib/nagios/plugins"
+
+/* The directory which you use to store additional plugins which ITL provides user contributed command definitions for.
+ * Check the documentation, chapter "Plugins Contribution", for details.
+ */
+const PluginContribDir = "/usr/lib/nagios/plugins"
+
+/* Our local instance name. By default this is the server's hostname as returned by `hostname --fqdn`.
+ * This should be the common name from the API certificate.
+ */
+//const NodeName = "localhost"
+
+/* Our local zone name. */
+const ZoneName = NodeName
+
+/* Secret key for remote node tickets */
+const TicketSalt = ""
+const NodeName = "{{ inventory_hostname_short }}.{{ freifunk.domain }}"
+

--- a/icinga2-server/templates/icinga2/features/api/api.conf.j2
+++ b/icinga2-server/templates/icinga2/features/api/api.conf.j2
@@ -1,0 +1,13 @@
+/* {{ ansible_managed }} */
+
+/**
+ * The API listener is used for distributed monitoring setups.
+ */
+
+object ApiListener "{{ inventory_hostname_short }}.{{ freifunk.domain }}" {
+  //accept_config = false
+  //accept_commands = false
+
+  ticket_salt = TicketSalt
+}
+

--- a/icinga2-server/templates/icinga2/features/api/api.conf.j2
+++ b/icinga2-server/templates/icinga2/features/api/api.conf.j2
@@ -9,5 +9,6 @@ object ApiListener "{{ inventory_hostname_short }}.{{ freifunk.domain }}" {
   //accept_commands = false
 
   ticket_salt = TicketSalt
+  bind_port = "{{ icinga2.api_listener.port | default(5665) }}"
+  bind_host = "{{ icinga2.api_listener.host | default("::") }}"
 }
-

--- a/icinga2-server/templates/icinga2/features/ido/ido-mysql.conf.j2
+++ b/icinga2-server/templates/icinga2/features/ido/ido-mysql.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+/* {{ ansible_managed }} */
 
 /**
  * The db_ido_mysql library implements IDO functionality

--- a/icinga2-server/templates/icingaweb2/resources.ini.j2
+++ b/icinga2-server/templates/icingaweb2/resources.ini.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+; {{ ansible_managed }}
 
 [icinga_ido]
 type = "db"

--- a/icinga2-server/templates/icingaweb2/roles.ini.j2
+++ b/icinga2-server/templates/icingaweb2/roles.ini.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+; {{ ansible_managed }}
 
 [Administratoren]
 users = "{{ icinga2.userliste | default() | selectattr('user','defined') | selectattr('pw', 'defined') | map(attribute='user') | list | join(",") }}"


### PR DESCRIPTION
### Fix:
- Behebe Abbruch der Rolle wegen fehlerhaftem Backslash in Ansible-Task

### Verbesserungen:
- Nutze statt libapache2-mod-php jetzt PHP-FPM mit Apache2 mpm_event (Standard seit Debian)
- PHP-Installation ist jetzt Versionsnummer-unabhängig
- Kommentare in den Konfigurationsdateien beginnen jetzt mit korrekten Kommentarzeichen
- Zertifikatshandling für Icinga2-API verbessert:
  - Hostname wird als CN ins Zertifikat eingetragen
  - CA-Zertifikat wird in "keyfiles" gespeichert
- Port und Listening-Adresse für IcingaWeb2 (Apache2) und Icinga2-API sind jetzt konfigurierbar
- Für Versand von Alert-E-Mails wird bsd-mailx installiert
- README.md aktualisiert
