### PR TITLE
exim4-daemon-light: Ansible-Regexp, SMTP-Helo-Hostname konfigurierbar

### DIFF
--- a/exim4-daemon-light/README.md
+++ b/exim4-daemon-light/README.md
@@ -9,8 +9,10 @@ mail:
   smtp: mail.foo.bar
   user: benutzername
   pw: geheim
+  force_hostname: gandalf.example.de
 ```
 
 Als Absenderadresse wird immer "icinga2@example.com" verwendet.
 Zur Authentifizierung am SMTP-Server "mail.foo.bar" wird der Benutzername "benutzername" und das Passwort "geheim" benutzt.
 
+`force_hostname` ist optional und setzt den Hostnamen, der für das SMTP-Helo am SMTP-Server verwendet wird.

--- a/exim4-daemon-light/tasks/main.yml
+++ b/exim4-daemon-light/tasks/main.yml
@@ -1,35 +1,53 @@
 - name: Install exim4-daemon-light
   apt:
-    pkg: [ 'exim4-daemon-light' ]
+    pkg: [ "exim4-daemon-light" ]
     state: present
 
 - name: Configure exim4
   template:
-    src: 'update-exim4.conf.conf.j2'
-    dest: '/etc/exim4/update-exim4.conf.conf'
+    src: "update-exim4.conf.conf.j2"
+    dest: "/etc/exim4/update-exim4.conf.conf"
   notify:
     - update-exim4.conf
     - restart exim4
 
 - name: Configure authentication at remote smtp server
   template:
-    src: 'passwd.client.j2'
-    dest: '/etc/exim4/passwd.client'
-    mode: '0640'
-    group: 'Debian-exim'
+    src: "passwd.client.j2"
+    dest: "/etc/exim4/passwd.client"
+    mode: "0640"
+    group: "Debian-exim"
   notify: restart exim4
 
 - name: Set sender email address
   template:
-    src: 'email-addresses.j2'
-    dest: '/etc/email-addresses'
+    src: "email-addresses.j2"
+    dest: "/etc/email-addresses"
   notify: restart exim4
 
-- name: Use sender email address for all users
+- name: Use sender email address for all local users
   replace:
     path: "/etc/exim4/exim4.conf.template"
-    regexp: '^(.*\${lookup{\${local_part} })lsearch({ /etc/email-addresses }.*)$'
+    regexp: '^(.*\${lookup{\${local_part}})lsearch({\s*\/etc\/email-addresses\s*}.*)$'
     replace: '\1wildlsearch\2'
+  notify: restart exim4
+
+- name: Set forced hostname for SMTP Helo
+  blockinfile:
+    path: "/etc/exim4/exim4.conf.template"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - FORCE HOSTNAME"
+    block: |
+      MAIN_HARDCODE_PRIMARY_HOSTNAME = {{ mail.force_hostname }}
+    insertbefore: BOF
+  when: mail.force_hostname is defined
+  notify: restart exim4
+
+- name: Remove forced hostname for SMTP Helo
+  blockinfile:
+    path: "/etc/exim4/exim4.conf.template"
+    marker: "# {mark} ANSIBLE MANAGED BLOCK - FORCE HOSTNAME"
+    state: absent
+  when: mail.force_hostname is not defined
   notify: restart exim4
 
 - name: Update logrotate cycle in /etc/logrotate.d/
@@ -45,7 +63,7 @@
   replace:
     dest: "{{ item }}"
     regexp: 'rotate[ \t]+[0-9]+'
-    replace: 'rotate {{ logrotate.count }}'
+    replace: "rotate {{ logrotate.count }}"
   with_items:
     - /etc/logrotate.d/exim4-base
     - /etc/logrotate.d/exim4-paniclog


### PR DESCRIPTION
- Passe Ansible-Regexp, die zur Konfiguration der Standard-E-Mailadresse des Absenders benutzt wird, an aktuelle Exim4-Version an.
- Mache den Hostnamen, der beim SMTP-Helo zum Mailserver geschickt wird, konfigurierbar.
- Kosmetik