### PR TITLE
bird: Benutze Variable ipv6backbone64prefixstr statt "2a03:2260:115:fa1::"

### DIFF
--- a/bird/templates/bird6.conf.j2
+++ b/bird/templates/bird6.conf.j2
@@ -158,9 +158,9 @@ template bgp internal {
 {% if hostvars[host].vm_id != vm_id %}
 protocol bgp ibgp_{{host|regex_replace('-','_')}} from internal {
 {% if hostvars[host].vm_id < vm_id %}
-	neighbor 2a03:2260:115:ffa1::{{hostvars[host].vm_id}}:{{vm_id}}:1 as {{ff_network.as_number}};
+	neighbor {{ipv6backbone64prefixstr}}{{hostvars[host].vm_id}}:{{vm_id}}:1 as {{ff_network.as_number}};
 {% else %}
-	neighbor 2a03:2260:115:ffa1::{{vm_id}}:{{hostvars[host].vm_id}}:0 as {{ff_network.as_number}};
+	neighbor {{ipv6backbone64prefixstr}}{{vm_id}}:{{hostvars[host].vm_id}}:0 as {{ff_network.as_number}};
 {% endif %}
 {% if hostvars[host].hoster|default('unknown') != hoster|default('unknown') %}
 	import filter {


### PR DESCRIPTION
In #124 wurde das hartkodierte IPv6-Prefix 2a03:2260:115:ffa1:: durch die Variable ipv6backbone64prefixstr ersetzt.
Die Variable wird für das Erstellen der bck-Schnittstellen benutzt, in /etc/bird/bird6.conf steht aber noch fix "2a03:2260:115:ffa1::".

Wurde wohl vergesen, im Sammel-PR #108 von wusel42 war die bird6.conf-Änderung noch drin.

