### PR TITLE
gateways_l2tp_slovenija: Erlaube Änderung der MTU

### DIFF
--- a/gateways_l2tp_slovenija/README.md
+++ b/gateways_l2tp_slovenija/README.md
@@ -17,7 +17,9 @@ Zur Konfiguration muss die Dictionary-Variable `tunneldigger` mit den beiden Ein
 tunneldigger:
   max_tunnels: 1024
   port_base: 20100
+  mtu: 1320
 ```
 
 - `max_tunnel` beschränkt die maximale Anzahl der verbundenen Clients auf den gesetzten Wert
 - `port_base` muss auf einen auf dem Gateway freien Port gesetzt werden und auch in der site.conf eingetragen werden.
+- `mtu` setzt die MTU für die L2TP-Tunnel. Wenn nicht gesetzt wird 1364 verwendet. Die MTU muss auch in der site.conf eingetragen werden.

--- a/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
@@ -24,7 +24,7 @@ connection_rate_limit=0.1
 ; Set PMTU to a fixed value.  Use 0 for automatic PMTU discovery.  A non-0 value also disables
 ; PMTU discovery on the client side, by having the server not respond to client-side PMTU
 ; discovery probes.
-pmtu=1364
+pmtu={{ tunneldigger.mtu | default(1364) }}
 
 [log]
 ; Verbosity


### PR DESCRIPTION
Erlaube Änderung der L2TP-Tunnel-MTU durch die Variable tunneldigger.mtu
Wenn nicht gesetzt wird der bisherige Wert 1364 beibehalten - für euch ändert sich also nichts.

Wir benutzen da aus historischen Gründen 1320. Die Clients scheinen zwar auch dann gut zu funktionieren wenn auf den Gateways 1364 benutzt wird, aber sicher ist sicher.