### PR TITLE
nrpe: check_websites-ipv4

### DIFF
--- a/icinga/templates/srv-gateways.conf
+++ b/icinga/templates/srv-gateways.conf
@@ -222,6 +222,28 @@ object Service "Check Bird6 Sessions" {
   vars.notification.hipchat = "1"
 }
 
+{% if nrpe.check_websites_upstream_ipv4 is defined and hostvars[item].ffrl_nat_ip is defined %}
+object Service "Check selected Websites via FFRL tunnel (HTTP/IPv4) " {
+  import "generic-service"
+  host_name = "{{ item }}"
+  check_command = "nrpe2"
+  vars.nrpe_command = "check_websites-ffrl-ipv4"
+  vars.sla = "24x7"
+  vars.notification.hipchat = "1"
+}
+{% endif %}
+
+{% if nrpe.check_websites_upstream_ipv4 is defined and hostvars[item].ffnw_nat_ip is defined %}
+object Service "Check selected Websites via FFNW tunnel (HTTP/IPv4) " {
+  import "generic-service"
+  host_name = "{{ item }}"
+  check_command = "nrpe2"
+  vars.nrpe_command = "check_websites-ffnw-ipv4"
+  vars.sla = "24x7"
+  vars.notification.hipchat = "1"
+}
+{% endif %}
+
 {% if hostvars[item].domaenenliste is defined %}
 {% for domaene in hostvars[item].domaenenliste|dictsort %}
 object Service "Check BATMAN Dom {{domaene[0]}} via IP" {

--- a/nrpe/files/check_websites-ipv4
+++ b/nrpe/files/check_websites-ipv4
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+PLUGINDIR=$(dirname "$0")
+. "${PLUGINDIR}/utils.sh"
+
+DOMAINS=()
+TIMEOUT=2
+
+while [[ $# -gt 0 ]]; do
+    opt="$1"
+    shift
+    case "${opt}" in
+	"-w" )	WARN="$1"; shift;;
+	"-c" )	CRIT="$1"; shift;;
+	"-s" )	SOURCE_IP="$1"; shift;;
+	"-t" )	TIMEOUT="$1"; shift;;
+	*)	DOMAINS+=("${opt}");;
+    esac
+done
+
+if [ -z "${CRIT}" ] || [ -z "${WARN}" ] || [ ${#DOMAINS[@]} -eq 0 ]; then
+    echo "$0 -w <WARNING> -c <CRITICAL> [-s <SOURCE_IP>] [-t TIMEOUT] DOMAIN [DOMAIN ...]"
+    echo
+    echo "    If at less than WARNING or CRITICAL percent of the domains are reachable within TIMEOUT seconds (default: 2) on HTTP, this script returns state WARNING or CRITICAL."
+    echo
+    echo "    If SOURCE_IP is set to an IP address or interface name, this is used to initiate the HTTP connections."
+    echo "    In that case a domain is skipped if it is also unreachable via the default interface."
+    echo
+    exit "${STATE_UNKNOWN}"
+fi
+
+DOMAINS_TOTAL=${#DOMAINS[@]}
+DOMAINS_OK=0
+
+PIDS=()
+for DOMAIN in "${DOMAINS[@]}"; do
+    (
+	if [ -n "${SOURCE_IP}" ]; then
+	    curl -4 --interface "${SOURCE_IP}" --max-time "${TIMEOUT}" --head --output /dev/null --silent http://"${DOMAIN}" && exit 0
+	    curl -4 --max-time "${TIMEOUT}" --head --output /dev/null --silent http://"${DOMAIN}" && exit 1
+	    exit 2
+	else
+	    curl -4 --max-time "${TIMEOUT}" --head --output /dev/null --silent http://"${DOMAIN}" && exit 0
+	    exit 1
+	fi
+    ) &
+    PIDS+=($!)
+done
+
+# Wait for all jobs to finish. The "wait" command forwards the exit state of the command that was executed in the background
+for P in ${PIDS[*]}; do
+    wait "$P"
+    RETVAL=$?
+    if [ ${RETVAL} -eq 0 ]; then
+	DOMAINS_OK=$((DOMAINS_OK+1))
+    elif [ ${RETVAL} -eq 2 ]; then
+	DOMAINS_TOTAL=$((DOMAINS_TOTAL-1))
+    fi
+done
+
+
+if [ ${DOMAINS_TOTAL} -eq 0 ]; then
+    echo "UNKNOWN: No domains to test"
+    exit "${STATE_UNKNOWN}"
+fi
+
+PERCENTAGE_OK=$((100*DOMAINS_OK/DOMAINS_TOTAL))
+PERFDATA="Domains reachable=${PERCENTAGE_OK}%;${WARN};${CRIT};0;100"
+
+if [ ${PERCENTAGE_OK} -lt "${CRIT}" ]; then
+    echo "CRITICAL: ${PERCENTAGE_OK}% of ${DOMAINS_TOTAL} domains reachable|${PERFDATA}"
+    exit "${STATE_CRITICAL}"
+elif [ ${PERCENTAGE_OK} -lt "${WARN}" ]; then
+    echo "WARNING: ${PERCENTAGE_OK}% of ${DOMAINS_TOTAL} domains reachable|${PERFDATA}"
+    exit "${STATE_WARNING}"
+else
+    echo "OK: ${PERCENTAGE_OK}% of ${DOMAINS_TOTAL} domains reachable|${PERFDATA}"
+    exit "${STATE_OK}"
+fi

--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -86,6 +86,9 @@
 - name: Install check_borg
   copy: "src=check_borg dest='/usr/lib/nagios/plugins/check_borg' owner=root group=root mode=a+x"
 
+- name: Install check_websites-ipv4
+  copy: "src=check_websites-ipv4 dest='/usr/lib/nagios/plugins/check_websites-ipv4' owner=root group=root mode=a+x"
+
 - name: Install sudo permissions
   template: "src=sudoers.j2 dest='/etc/sudoers.d/nrpe' owner=root group=root mode=440"
 

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -49,6 +49,12 @@ command[check_iproute]=/usr/lib/nagios/plugins/check_iproute
 command[check_iproute6]=/usr/lib/nagios/plugins/check_iproute6 
 command[check_bird_sessions]=sudo /usr/lib/nagios/plugins/check_bird_sessions
 command[check_bird6_sessions]=sudo /usr/lib/nagios/plugins/check_bird6_sessions
+{% if nrpe.check_websites_upstream_ipv4 is defined and ffrl_nat_ip is defined %}
+command[check_websites-ffrl-ipv4]=/usr/lib/nagios/plugins/check_websites-ipv4 -t 2 -s {{ ffrl_nat_ip }} -w 99 -c 95 {{ nrpe.check_websites_upstream_ipv4 }}
+{% endif %}
+{% if nrpe.check_websites_upstream_ipv4 is defined and ffnw_nat_ip is defined %}
+command[check_websites-ffnw-ipv4]=/usr/lib/nagios/plugins/check_websites-ipv4 -t 2 -s {{ ffnw_nat_ip }} -w 99 -c 95 {{ nrpe.check_websites_upstream_ipv4 }}
+{% endif %}
 
 # Service VM Server
 command[check_nginx]=/usr/lib/nagios/plugins/check_procs -c 1: -w 1: -C nginx


### PR DESCRIPTION
Prüfe Erreichbarkeit von ausgewählten Webseiten über FFRL/FFNW per HTTP und IPv4
Ziel: Erkennen von Routingproblemen bei FFRL/FFNW

**Konfiguration**:
```
nrpe:
  check_websites_upstream_ipv4: foo.com bar.de baz.net ...
```

**Funktionsweise:**
Das Check-Skript arbeitet zweistufig um Alerts durch kaputte Webserver zu vermeiden:
1. Es wird versucht, alle gelisteten Domains per IPv4-NAT-Adresse des Upstream-Tunnels (FFRL/FFNW) zu erreichen.
2. Gelingt das bei einer Domain nicht, dann wird versucht, die Domain über das Default-Interface des Gateways zu erreichen (also ohne Tunnel): Nur wenn das gelingt wird ein Problem gemeldet.

Das Check-Skript liefert den Prozentsatz an problemfreien Domains zurück. "Warning" gibt's ab 99%, "Critical" ab 95%.

**Obacht:** Die Integration in die Rolle "icinga" ist ungetestet, ebenso der Test der FFNW-Tunnel. Wir haben keine FFNW-Tunnel und benutzen eine andere Rolle für Icinga2 als ihr (icinga2-server). Ich habe trotzdem versucht, das nach bestem Wissen einzubauen. Solltet ihr einen Fehler findet einfach Bescheid geben, ich ändere den Pull Request dann entsprechend.

**Welche Domains verwenden?**
Wir bei FF Ingolstadt verwenden als zu prüfende Domains die Alexa-Top-50-Liste für Deutschland. Dazu setzen wir im Ansible-Inventory die Variable nrpe.check_websites_upstream_ipv4 beim Ausrollen per Lookup-Skript und ergänzen sie um ein paar Domains die in der Vergangenheit bereits Probleme gemacht haben. Das sieht dann so aus:
```
nrpe:
   check_websites_upstream_ipv4: "{{ lookup('pipe','scripts/alexa-top-50-domains.py DE') }} twitter.com consorsbank.de"
```
Das Lookup-Skript liegt hier https://git.bingo-ev.de/freifunk/ansible-ffin/blob/master/scripts/alexa-top-50-domains.py und holt sich die Domains per Web-Scraping.

Da das Skript ein Inventory-Skript ist und Web-Scraping tendenziell instabil ist, ist das Skript nicht Bestandteil dieses Pull Requests. Wenn ihr wollt könnt ihr das natürlich auch in euer Inventory aufnehmen.