### PR TITLE
Korrektur unattended-upgrades template für ubuntu

### DIFF
--- a/unattended_upgrades/templates/50unattended-upgrades-ubuntu.j2
+++ b/unattended_upgrades/templates/50unattended-upgrades-ubuntu.j2
@@ -16,13 +16,13 @@ Unattended-Upgrade::Allowed-Origins {
 //	"${distro_id}:${distro_codename}-updates";
 //	"${distro_id}:${distro_codename}-proposed";
 //	"${distro_id}:${distro_codename}-backports";
-+{% if unattended_upgrades.origins_pattern is defined and unattended_upgrades.origins_pattern %}
-+
-+        // Custom matching:
-+{% for item in unattended_upgrades.origins_pattern %}
-+        "{{ item }}";
-+{% endfor %}
-+{% endif %}
+{% if unattended_upgrades.origins_pattern is defined and unattended_upgrades.origins_pattern %}
+
+        // Custom matching:
+{% for item in unattended_upgrades.origins_pattern %}
+        "{{ item }}";
+{% endfor %}
+{% endif %}
 };
 
 // List of packages to not update (regexp are supported)
@@ -38,7 +38,7 @@ Unattended-Upgrade::Package-Blacklist {
 Unattended-Upgrade::DevRelease "false";
 
 // This option allows you to control if on a unclean dpkg exit
-// unattended-upgrades will automatically run 
+// unattended-upgrades will automatically run
 //   dpkg --force-confold --configure -a
 // The default is true, to ensure updates keep getting installed
 //Unattended-Upgrade::AutoFixInterruptedDpkg "false";
@@ -73,7 +73,7 @@ Unattended-Upgrade::MinimalSteps "true";
 //Unattended-Upgrade::Remove-Unused-Dependencies "false";
 
 // Automatically reboot *WITHOUT CONFIRMATION*
-//  if the file /var/run/reboot-required is found after the upgrade 
+//  if the file /var/run/reboot-required is found after the upgrade
 //Unattended-Upgrade::Automatic-Reboot "false";
 
 // If automatic reboot is enabled and needed, reboot at the specific


### PR DESCRIPTION
Ich denke mal die + sind aus irgendeinem merge/merge-konflikt oder so mal rein gekommen.