### PR TITLE
icinga2-server: Kompatibilität mit Ubuntu 18.04

### DIFF
--- a/icinga2-server/README.md
+++ b/icinga2-server/README.md
@@ -42,4 +42,4 @@ Das von Icinga2 dafür erzeugte CA-Zertifikat wird auf dem Ansible-Controller un
 Auf IcingaWeb2 kann, wenn nicht anders konfiguriert, über http, Port 80, zugegriffen werden.
 
 ## Kompatibilität:
-Derzeit nur Debian 10
+Debian 10, Ubuntu 18.04, Ubuntu 20.04

--- a/icinga2-server/templates/icinga2/constants.conf.j2
+++ b/icinga2-server/templates/icinga2/constants.conf.j2
@@ -5,6 +5,11 @@
  * the other configuration files.
  */
 
+{% if ansible_distribution == 'Ubuntu' and ansible_distribution_version == '18.04' %}
+/* Main configuration directory */
+const ConfigDir = "/etc/icinga2"
+{% endif %}
+
 /* The directory which contains the plugins from the Monitoring Plugins project. */
 const PluginDir = "/usr/lib/nagios/plugins"
 


### PR DESCRIPTION
Ubuntu 18.04 verwendet zum Auffinden des Verzeichnisses "/etc/icinga2" statt der offiziellen, in der Icinga2-Doku geforderten Variable "ConfigDir" die Variable "SysconfDir".
Setze darum unter Ubuntu 18 explizit die Variable "ConfigDir" auf "/etc/icinga2".
Damit funktioniert die Rolle auch unter Ubuntu 18.04.