### PR TITLE
gateways_respondd: Fix für's Ausrollen

### DIFF
--- a/gateways_respondd/tasks/main.yml
+++ b/gateways_respondd/tasks/main.yml
@@ -10,6 +10,7 @@
     dest: /opt/mesh-announce
     clone: yes
     update: yes
+    force: yes
   notify: restart respondd
 
 - name: patch hostname.py


### PR DESCRIPTION
Da das in der Rolle Repository lokal gepatcht wird muss beim beim Erneuten Auschecken "force" verwendet werden, sonst bricht die Rolle ab.