### PR TITLE
Ersetze überall "ansible_ssh_host" durch "ipv4"

### DIFF
--- a/backbone_gre_intern/templates/gre_interbackbone.j2
+++ b/backbone_gre_intern/templates/gre_interbackbone.j2
@@ -10,7 +10,7 @@ iface bck-{{host}} inet static
         address 192.168.{{ vm_id-1 }}.{{hostvars[host].vm_id*2}}
 {% endif %}
         netmask 31
-        pre-up ip link add $IFACE type gre local {{ansible_default_ipv4.address}} remote {{hostvars[host].ansible_ssh_host}} ttl 255
+        pre-up ip link add $IFACE type gre local {{ansible_default_ipv4.address}} remote {{hostvars[host].ipv4}} ttl 255
         pre-up ip link set $IFACE up multicast on
         post-up ip rule add iif $IFACE table ffnet
         pre-down ip rule del iif $IFACE table ffnet ||:

--- a/collectd/templates/collectd.conf.j2
+++ b/collectd/templates/collectd.conf.j2
@@ -626,7 +626,7 @@ LoadPlugin write_graphite
 {% endfor %}
 {% for host in groups['gateways'] %}
 {% if "domaenenliste" in hostvars[host] %}
-{% if ansible_ssh_host != hostvars[host].ansible_ssh_host and domaene[0] in hostvars[host].domaenenliste and hosts.append(host) %}
+{% if ipv4 != hostvars[host].ipv4 and domaene[0] in hostvars[host].domaenenliste and hosts.append(host) %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/dienste_bind/templates/db.tld-template.j2
+++ b/dienste_bind/templates/db.tld-template.j2
@@ -9,7 +9,7 @@ $TTL 86400
 {% set i = [1] %}
 {% for host in item.value.extern_dns %}
 @                       IN  NS      ns{{i[0]}}
-ns{{i[0]}}                     IN  A       {{hostvars[host].ansible_ssh_host }}
+ns{{i[0]}}                     IN  A       {{hostvars[host].ipv4 }}
 {% if i.append(i.pop() + 1) %}{% endif %}
 {% endfor %}
 

--- a/dienste_bind/templates/named.conf.tld.j2
+++ b/dienste_bind/templates/named.conf.tld.j2
@@ -5,7 +5,7 @@ zone "{{domain}}." IN {
 	allow-transfer {
 	   localhost;
 {% for host in groups['gateways'] %}
-	   {{hostvars[host].ansible_ssh_host }};
+	   {{hostvars[host].ipv4 }};
 {% endfor %}
 	};
 };
@@ -15,7 +15,7 @@ zone "servers.{{domain}}." IN {
 	allow-transfer {
 	   localhost;
 {% for host in groups['gateways'] %}
-           {{hostvars[host].ansible_ssh_host }};
+           {{hostvars[host].ipv4 }};
 {% endfor %}
 	};
 };
@@ -25,7 +25,7 @@ zone "services.{{domain}}." IN {
 	allow-transfer {
 	   localhost;
 {% for host in groups['gateways'] %}
-           {{hostvars[host].ansible_ssh_host }};
+           {{hostvars[host].ipv4 }};
 {% endfor %}
 	};
 };
@@ -35,7 +35,7 @@ zone "knoten.{{domain}}." IN {
 	allow-transfer {
 	   localhost;
 {% for host in groups['gateways'] %}
-           {{hostvars[host].ansible_ssh_host }};
+           {{hostvars[host].ipv4 }};
 {% endfor %}
 	};
 };

--- a/gateways_gretap/templates/gretap.j2
+++ b/gateways_gretap/templates/gretap.j2
@@ -13,14 +13,14 @@
 {% endif %}
 {% endfor %}
 {% for host in groups['gateways'] %}
-{% if ansible_ssh_host != hostvars[host].ansible_ssh_host and hostvars[host].domaenenliste is defined and domaene[0] in hostvars[host].domaenenliste and hosts.append(host) %}
+{% if ipv4 != hostvars[host].ipv4 and hostvars[host].domaenenliste is defined and domaene[0] in hostvars[host].domaenenliste and hosts.append(host) %}
 {% endif %}
 {% endfor %}
 {% for host in hosts %}
 {% if hostvars[host] is defined %}
 {% if indexer.append(indexer.pop() + 1) %}{% endif %}{# increment indexer by 1 #}
 
-# GRETAP Tunnel for domaene-{{domaene[0]}} to {{host}} ({{hostvars[host].ansible_ssh_host}})
+# GRETAP Tunnel for domaene-{{domaene[0]}} to {{host}} ({{hostvars[host].ipv4}})
 auto t{{domaene[0]}}-{{host}}
 iface t{{domaene[0]}}-{{host}} inet manual
 {% if build_tunnels_over_ipv6_if_available is defined and build_tunnels_over_ipv6_if_available and ipv6 is defined and hostvars[host].ipv6 is defined %}

--- a/icinga/tasks/main.yml
+++ b/icinga/tasks/main.yml
@@ -179,11 +179,11 @@
   shell: openssl x509 -in /etc/letsencrypt/live/{{inventory_hostname_short}}.{{freifunk.domain}}/cert.pem -noout -subject | sed -e 's/.*CN=//g'
   register: openssl_out
 
-- name: Register Domains for {{ansible_ssh_host}} in /etc/hosts
+- name: Register Domains for {{ipv4}} in /etc/hosts
   lineinfile:
    path: /etc/hosts
-   regexp: '^{{ansible_ssh_host}}'
-   line: '{{ansible_ssh_host}} {{openssl_out.stdout}} {% for domain in domains %}{{inventory_hostname_short}}.{{domain}} {% endfor %}{{inventory_hostname_short}}'
+   regexp: '^{{ipv4}}'
+   line: '{{ipv4}} {{openssl_out.stdout}} {% for domain in domains %}{{inventory_hostname_short}}.{{domain}} {% endfor %}{{inventory_hostname_short}}'
 
 - name: Register Domains for 127.0.0.1 in /etc/hosts
   lineinfile:

--- a/icinga/templates/srv-gateways.conf
+++ b/icinga/templates/srv-gateways.conf
@@ -5,7 +5,7 @@
 object Host "{{ item }}" {
   import "generic-host"
   import "host-perf"
-  address = "{{ hostvars[item].ansible_ssh_host }}"
+  address = "{{ hostvars[item].ipv4 }}"
   check_command = "hostalive"
   groups = [ "gateways" ]
   vars.sla = "24x7"

--- a/icinga/templates/srv-icinga.conf
+++ b/icinga/templates/srv-icinga.conf
@@ -5,7 +5,7 @@
 object Host "{{ item }}" {
   import "generic-host"
   import "host-perf"
-  address = "{{ hostvars[item].ansible_ssh_host }}"
+  address = "{{ hostvars[item].ipv4 }}"
   check_command = "hostalive"
   vars.sla = "24x7"
   vars.notification.hipchat = "1"

--- a/icinga/templates/srv-satellites.conf
+++ b/icinga/templates/srv-satellites.conf
@@ -4,7 +4,7 @@
 
 object Host "{{ item }}" {
   import "generic-host"
-  address = "{{ hostvars[item].ansible_ssh_host }}"
+  address = "{{ hostvars[item].ipv4 }}"
   check_command = "hostalive"
   vars.sla = "24x7"
 }

--- a/icinga/templates/vip-nodes.conf
+++ b/icinga/templates/vip-nodes.conf
@@ -4,7 +4,7 @@
 
 object Host "{{ item }}" {
   import "generic-host"
-  address6 = "{{ hostvars[item].ansible_ssh_host }}"
+  address6 = "{{ hostvars[item].ipv6 }}"
   check_command = "ping6"
   vars.sla = "24x7"
   vars.notification.hipchat = "1"

--- a/nrpe/templates/nrpe_local.cfg.j2
+++ b/nrpe/templates/nrpe_local.cfg.j2
@@ -3,7 +3,7 @@
 connection_timeout=600
 command_timeout=600
 
-allowed_hosts=127.0.0.1,{{ ansible_default_ipv4.address }},{{ groups['monitoring']|default([]) | map('extract',hostvars, ['ansible_ssh_host']) | join(',') }}
+allowed_hosts=127.0.0.1,{{ ansible_default_ipv4.address }},{{ groups['monitoring']|default([]) | map('extract',hostvars, ['ipv4']) | join(',') }}
 
 # Speedtest
 command[check_speedtest-cli-2]=/usr/lib/nagios/plugins/check_speedtest-cli.sh -w 2 -c 1 -W 0.2 -C 0.1 -p -s 4193


### PR DESCRIPTION
Ausnahme: In icinga/templates/vip-nodes.conf durch "ipv6"

Jetzt, wo HellMar mit 84bd4fbc65bb6d6000028fdd45473f12567bc4d5 ~~den ersten Stein geworfen~~ die Initiative ergriffen hat:

Wenn "ansible_ssh_host" statt "ipv4" verwendet wird gibt's Probleme, wenn z.B. aus einem IPv6-Netz ausgerollt wird und die Hosts darum von Ansible mit ihren IPv6-Adressen angesprochen werden müssen. Ähnlich z.B. beim testweisen Installieren auf VMs im lokalen Netzwerk: Es tauchen sporadisch die falschen IP-Adressen in der Konfiguration auf oder Rollen brechen ab, ein Vergleich mit den produktiven Servern ist so ziemlich schwierig.

**Achtung:**
- Ihr habt in eurem Inventory nicht für alle Hosts "ipv4" gesetzt. Wenn ihr diesen PR übernehmen wollt müsstet ihr das noch tun.
- Ich hab's nur für die Rollen getestet, die wir in Ingolstadt verwenden: Beim Ausrollen auf den Servern gab's keine Konfigurationsänderungen gegenüber dem vorherigen Zustand. Ihr müsstet das für die von euch benutzten Rollen auch noch testen.