### PR TITLE
gateways_respondd: Anpassung an aktuelles mesh-announce

### DIFF
--- a/gateways_respondd/tasks/main.yml
+++ b/gateways_respondd/tasks/main.yml
@@ -16,7 +16,14 @@
   template:
     src: hostname.py.j2
     dest: /opt/mesh-announce/providers/nodeinfo/hostname.py
-  notify: systemctl reload
+  when: domaenenliste is defined and domaenenliste | length > 1
+  notify: restart respondd
+
+- name: create configuration
+  template:
+    src: respondd.conf.j2
+    dest: /opt/mesh-announce/respondd.conf
+  notify: restart respondd
 
 - name: create systemd file
   template:

--- a/gateways_respondd/templates/respondd.conf.j2
+++ b/gateways_respondd/templates/respondd.conf.j2
@@ -1,0 +1,33 @@
+# {{ ansible_managed }}
+
+# Default settings
+[Defaults]
+# Listen port
+# optional, default: 1001
+Port: 1001
+# Default link local listen addresses
+# optional, default: ff02::2:1001
+MulticastLinkAddress: ff02::2:1001
+# Default site local listen addresses
+# optional, default: ff05::2:1001
+MulticastSiteAddress: ff05::2:1001
+# Default domain to use
+# optional, if specified incoming requests that can not be mapped to a domain
+# are mapped to this domain
+DefaultDomain: {{ freifunk.kurzname }}
+# Default domain type
+# optional, default: simple
+# supported domain types are: simple, batadv
+DomainType: batadv
+# Default ddhcpd IPv4 gateway address
+# optional
+#IPv4Gateway: 10.116.128.8
+
+# An arbitrary number of further domains may follow here
+{% for domaene in domaenenliste|dictsort %}
+[{{ freifunk.kurzname }}d{{ domaene[0] }}]
+BatmanInterface: bat{{ domaene[0] }}
+Interfaces: br{{ domaene[0] }}
+IPv4Gateway: {{ domaenen[domaene[0]].ffv4_network | ipaddr(domaene[1].server_id) | ipaddr('address') }}
+
+{% endfor %}

--- a/gateways_respondd/templates/respondd.service.j2
+++ b/gateways_respondd/templates/respondd.service.j2
@@ -3,7 +3,7 @@ Description=Respondd
 After=network.target
 
 [Service]
-ExecStart=/opt/mesh-announce/respondd.py -d /opt/mesh-announce/providers {{ domaenenliste.keys() | map('regex_replace', '^(.*)$', '-i br\\1 -i bat\\1 -b bat\\1') | join(" ") }}
+ExecStart=/opt/mesh-announce/respondd.py -d /opt/mesh-announce/providers -f /opt/mesh-announce/respondd.conf
 Restart=on-failure
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 


### PR DESCRIPTION
- Aktuelles mesh-announce benötigt eine Konfigurationsdatei statt Kommandozeilenparameter
- Der Patch für's Hinzufügen der Domäne zu den Gateway-Hostnamen ist leider immer noch notwendig

Bitte unbedingt vor dem Mergen testen, wir haben in Ingolstadt nur eine einzige Domäne