### PR TITLE
gateways_l2tp_slovenija: python3-virtualenv statt python-virtualenv

### DIFF
--- a/gateways_l2tp_slovenija/tasks/main.yml
+++ b/gateways_l2tp_slovenija/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Install dependencies for this role
   apt:
-    pkg: ['git', 'libnetfilter-conntrack-dev', 'libnfnetlink-dev', 'python3-dev', 'python-virtualenv', 'gcc',
-      'libnl-3-dev', 'libevent-dev', 'bridge-utils', 'ebtables', 'iproute2']
+    pkg: [ 'git', 'libnetfilter-conntrack-dev', 'libnfnetlink-dev', 'python3-dev', 'python3-virtualenv',
+      'virtualenv', 'gcc', 'libnl-3-dev', 'libevent-dev', 'bridge-utils', 'ebtables', 'iproute2' ]
   when: domaenenliste is defined
 
 - name: Get all enabled tunneldigger (domain specific) instances


### PR DESCRIPTION
In Debian 11 und Ubuntu 20.04 wird statt dem Paket python-virtualenv das Paket python3-virtualenv benötigt.
Für Debian 9 und Ubuntu 16.04 zusätzlich das Paket virtualenv.