### PR TITLE
gateways_batman: Verbessere Formatierung von "hwaddress"

### DIFF
--- a/gateways_batman/templates/batman.j2
+++ b/gateways_batman/templates/batman.j2
@@ -10,9 +10,9 @@ iface bat{{item[0]}} inet static
         address {{domaenen[item[0]].ffv4_network | ipaddr(item[1].server_id) | ipaddr('address') }}
         netmask {{domaenen[item[0]].ffv4_network | ipaddr('netmask')}}
 {% if item[0] | length > 2 %}
-        hwaddress f2:be:ef:{{item[0][0:2]}}:{{item[0][2:]}}:{{item[1].server_id}}
+        hwaddress f2:be:ef:{{item[0][0:2]}}:{{item[0][2:]}}:{{ "{:02}".format(item[1].server_id) }}
 {% else %}
-        hwaddress f2:be:ef:00:{{item[0]}}:{{item[1].server_id}}
+        hwaddress f2:be:ef:00:{{item[0]}}:{{ "{:02}".format(item[1].server_id) }}
 {% endif %}
         pre-up modprobe batman-adv
         pre-up ip link add bat{{item[0]}} type batadv


### PR DESCRIPTION
In /etc/network/interfaces.d/10_batman.cfg wird den Batman-Interfaces eine MAC-Adresse zugewiesen.
Diese "hwaddress" wird u.a. aus der server_id gebildet. Wenn diese einstellig ist, dieser eine "0" voranstellen.

**Beispiel:** (server_id=4)
Bisher:

```
auto bat10
iface bat10 inet static
  [...]
  hwaddress f2:be:ef:00:10:4
  [...]
```
Mit diesem Patch:
```
auto bat10
iface bat10 inet static
  [...]
  hwaddress f2:be:ef:00:10:04
  [...]
```

Im Unterschied zu IPv6-Adressen scheint nicht klar definiert zu sein, wie bei MAC-Adressen mit fehlenden führenden Nullen umzugehen ist.
