### PR TITLE
gateways_dhcp: Verbessere Formatierung von INTERFACESv4

### DIFF
--- a/gateways_dhcp/templates/isc-dhcp-server.j2
+++ b/gateways_dhcp/templates/isc-dhcp-server.j2
@@ -16,6 +16,5 @@
 
 # On what interfaces should the DHCP server (dhcpd) serve DHCP requests?
 #       Separate multiple interfaces with spaces, e.g. "eth0 eth1".
-INTERFACESv4="{% for domaene in domaenenliste|dictsort %}bat{{domaene[0]}} {% endfor %}"
+INTERFACESv4="{% for domaene in domaenenliste|dictsort %}bat{{ domaene[0] }}{% if not loop.last %} {% endif %}{% endfor %}"
 INTERFACESv6=""
-


### PR DESCRIPTION
/etc/default/isc-dhcp-server enthält die Variable INTERFACESv4 mit einer
Liste aller Batman-Interfaces.
Dieser Patch entfernt das Leerzeichen nach dem letzten Interface.

Vorher: `INTERFACESv4="bat10 bat11 "`
Nachher: `INTERFACESv4="bat10 bat11"`