### PR TITLE
gateways_l2tp(_slovenija): Flexiblere Portkonfiguration

### DIFF
--- a/gateways_l2tp/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp/templates/l2tp_broker.cfg.j2
@@ -3,11 +3,11 @@
 address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
 {% if tunneldigger.instance_per_domain == True %}
-port={{20000 + (item.key | int)}}
+port={{ tunneldigger.listening_port_base | default(20000) + (item.key | int) }}
 {% else %}
 {% set ports = [] %}
 {% for domaene in domaenenliste|dictsort %}
-{% if ports.append(20000 + (domaene[0] | int )) %}{% endif %}
+{% if ports.append(tunneldigger.listening_port_base | default(20000) + (domaene[0] | int )) %}{% endif %}
 {% endfor %}
 port={{ports|join(',')}}
 {% endif %}

--- a/gateways_l2tp_slovenija/README.md
+++ b/gateways_l2tp_slovenija/README.md
@@ -5,21 +5,23 @@ Diese Rolle installiert auf Gateways tunneldigger von https://github.com/wlanslo
 Für jede Domäne wird eine eigene tunneldigger-Instanz gestartet.
 
 ## Konfiguration
-Die Broker-Komponente von Tunneldigger lauscht auf eingehende Verbindungen auf Port 20000 + Domänennummer, also z.B. für Domäne 11 auf Port 20011.
-Dieser Port muss für die Access Points in der `site.conf` unter `mesh_vpn.tunneldigger.brokers` angegeben werden.
+Die Broker-Komponente von Tunneldigger lauscht auf eingehende Verbindungen auf einem von außen erreichenbaren Port.
+Der von außen erreichbare Port muss für die Access Points in der `site.conf` unter `mesh_vpn.tunneldigger.brokers` angegeben werden.
 
-Der L2TP-Tunnel selbst wird dann vom Gateway über den unten mit `port_base` konfigurierten Port aufgebaut und in die von der Rolle "gateways_batman" Netzwerkbrücke eingehängt.
+Der L2TP-Tunnel selbst wird dann vom Gateway über einen internen Port aufgebaut und in die von der Rolle "gateways_batman" erstellte Netzwerkbrücke eingehängt.
 
-Zur Konfiguration muss die Dictionary-Variable `tunneldigger` mit den beiden Einträgen `max_tunnels` und `port_base` gesetzt werden, üblicherweise in den `group_vars`:
+Zur Konfiguration muss die Dictionary-Variable `tunneldigger` mindestens mit dem Eintrag `max_tunnels` gesetzt werden, üblicherweise in den `group_vars`:
 
 **Beispiel:**
 ```
 tunneldigger:
   max_tunnels: 1024
+  listening_port_base: 20000
   port_base: 20100
   mtu: 1320
 ```
 
-- `max_tunnel` beschränkt die maximale Anzahl der verbundenen Clients auf den gesetzten Wert
-- `port_base` muss auf einen auf dem Gateway freien Port gesetzt werden und auch in der site.conf eingetragen werden.
+- `max_tunnels` beschränkt die maximale Anzahl der verbundenen Clients auf den gesetzten Wert
+- `listening_port_base` legt den von Startwert zur Berechnung des von außen erreichbaren Port fest (Default: 20000). Der Broker lauscht auf dem Port `listening_port_base` + Domänennummer.
+- `port_base` legt den Startwert zur Berechnung des intern auf dem Gateway verwendeten Port fest (Default: 20100). Verwendet wird der Port `port_base` + Domänennummer.
 - `mtu` setzt die MTU für die L2TP-Tunnel. Wenn nicht gesetzt wird 1364 verwendet. Die MTU muss auch in der site.conf eingetragen werden.

--- a/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
@@ -2,7 +2,7 @@
 ; IP address the broker will listen and accept tunnels on
 address={{ansible_default_ipv4.address}}
 ; Ports where the broker will listen on
-port={{20000 + (item.key | int)}}
+port={{ tunneldigger.listening_port_base | default(20000) + (item.key | int) }}
 ; Interface with that IP address
 interface={{ansible_default_ipv4.interface}}
 ; Maximum number of tunnels that will be allowed by the broker
@@ -10,7 +10,7 @@ max_tunnels={{ tunneldigger.max_tunnels - 1 }}
 ; Tunnel port base. This port is not visible to clients, but must be free on the server.
 ; This port is used by the actual l2tp tunnel, but tunneldigger sets up NAT rules so that clients
 ; can keep using the control port.
-port_base={{tunneldigger.port_base}}
+port_base={{ tunneldigger.port_base | default(20100) }}
 ; Tunnel id base
 tunnel_id_base={% for domaene in domaenenliste %}{% if domaene == item.key %}{{loop.index * tunneldigger.max_tunnels - tunneldigger.max_tunnels}}{% endif %}{% endfor %}
 


### PR DESCRIPTION
Bisher ist der externe Port des L2TP-Brokers fix (20000 + Domänennummer), der interne Port muss dagegen zwangsweise im Inventory konfiguriert werden.

Dieser Patch macht auch den externen Port einstellbar, Default ist, wie bisher, 20000 + Domänennummer.
Der interne Port muss nicht mehr zwangsweise in der Konfiguration angegeben werden, kann aber.

- `tunneldigger.listening_port_base` legt den von Startwert zur Berechnung des von außen erreichbaren Port fest (Default: 20000). Der Broker lauscht auf dem Port `listening_port_base` + Domänennummer.
- `tunneldigger.port_base` legt den Startwert zur Berechnung des intern auf dem Gateway verwendeten Port fest (Default: 20100). Verwendet wird der Port `port_base` + Domänennummer.

Das macht die Konfiguration etwas schlanker und erleichtert das Einrichten von Test-Gateways.