### PR TITLE
unattended_upgrades: Debian 11-Support

### DIFF
--- a/unattended_upgrades/templates/50unattended-upgrades-debian.j2
+++ b/unattended_upgrades/templates/50unattended-upgrades-debian.j2
@@ -32,6 +32,7 @@ Unattended-Upgrade::Origins-Pattern {
 //      "origin=Debian,codename=${distro_codename}-proposed-updates";
 //      "origin=Debian,codename=${distro_codename},label=Debian";
         "origin=Debian,codename=${distro_codename},label=Debian-Security";
+        "origin=Debian,codename=${distro_codename}-security,label=Debian-Security";
 
         // Archive or Suite based matching:
         // Note that this will silently match a different release after


### PR DESCRIPTION
Bei Debian 11 liegen die Security-Updates in einem anderen Repo-Zweig.
Erlaube unattended_upgrades automatische Upgrades auch daraus.