### PR TITLE
Repariere Rollen für Setups ohne AS-Router

### DIFF
--- a/backbone_gre_intern/templates/gre_interbackbone.j2
+++ b/backbone_gre_intern/templates/gre_interbackbone.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
-{% for host in groups['gateways']+groups['as_router'] %}
-{% if host != inventory_hostname and not ( inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
+{% for host in groups['gateways'] | default([]) + groups['as_router'] | default([]) %}
+{% if host != inventory_hostname and not ('as_router' in groups and inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
 auto bck-{{host}}
 iface bck-{{host}} inet tunnel
 	mode gre

--- a/bird/templates/bird.conf.j2
+++ b/bird/templates/bird.conf.j2
@@ -219,7 +219,7 @@ protocol bgp ffnw_{{tun.name}} from uplink {
 {% endif %}
 
 {% for host in groups['gateways']|default([]) %}
-{% if hostvars[host].vm_id != vm_id and not ( inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
+{% if hostvars[host].vm_id != vm_id and not ( 'as_router' in groups and inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
 protocol bgp ibgp_{{host|regex_replace('-','_')}} from internal {
 {% if hostvars[host].vm_id < vm_id %}
 	neighbor 192.168.{{ hostvars[host].vm_id-1 }}.{{vm_id*2}} as {{as_parameters.as_number}};

--- a/bird/templates/bird6.conf.j2
+++ b/bird/templates/bird6.conf.j2
@@ -1,10 +1,10 @@
- {{ ansible_managed }}
+# {{ ansible_managed }}
 
 log syslog { debug, trace, info, remote, warning, error, auth, fatal, bug };
 {% if 'as_router' in groups and 'as_router' in group_names %}
 router id {{ as_ip }};
 {% else %}
-router id { vm_id }};
+router id {{ vm_id }};
 {% endif %}
 
 table ffnet;
@@ -38,7 +38,7 @@ protocol radv {
 		link mtu 1280;
 		prefix {{domaenen[domaene[0]].ffv6_network}} {
 		};
-{% for prefix in domaenen[domaene[0]].ffv6_additional_networks %}
+{% for prefix in domaenen[domaene[0]].ffv6_additional_networks | default([]) %}
 		prefix {{prefix}} {
 		};
 {% endfor %}
@@ -117,7 +117,7 @@ protocol static static_domaene{{domaene[0]}} {
 	route {{domaenen[domaene[0]].ffv6_network | regex_replace('..::/\d+$','00::/56')}} reject {
 		ra_preference = RA_PREF_HIGH;
 	};
-{% for prefix in domaenen[domaene[0]].ffv6_additional_networks %}
+{% for prefix in domaenen[domaene[0]].ffv6_additional_networks | default([]) %}
 	route {{prefix}} reject {
 		ra_preference = RA_PREF_MEDIUM;
 	};
@@ -168,7 +168,7 @@ template bgp internal {
 {% for host in groups['gateways']|default([]) %}
 {% if hostvars[host].vm_id != vm_id %}
 protocol bgp ibgp_{{host|regex_replace('-','_')}} from internal {
-{% if hostvars[host].vm_id < vm_id and not ( inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
+{% if hostvars[host].vm_id < vm_id and not ( 'as_router' in groups and inventory_hostname in groups['as_router'] and host in groups['as_router'] ) %}
 	neighbor {{ipv6backbone64prefixstr}}{{hostvars[host].vm_id}}:{{vm_id}}:1 as {{ff_network.as_number}};
 {% else %}
 	neighbor {{ipv6backbone64prefixstr}}{{vm_id}}:{{hostvars[host].vm_id}}:0 as {{ff_network.as_number}};

--- a/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
+++ b/gateways_l2tp_slovenija/templates/l2tp_broker.cfg.j2
@@ -4,7 +4,7 @@ address={{ipv4}}
 ; Ports where the broker will listen on
 port={{ tunneldigger.listening_port_base | default(20000) + (item.key | int) }}
 ; Interface with that IP address
-interface={{tunneldigger.interface}}
+interface={{ tunneldigger.interface | default(ansible_default_ipv4.interface) }}
 ; Maximum number of tunnels that will be allowed by the broker
 max_tunnels={{ tunneldigger.max_tunnels - 1 }}
 ; Tunnel port base. This port is not visible to clients, but must be free on the server.


### PR DESCRIPTION
Einige Rollen brechen ab, wenn es im Inventory keine "as_router"-Gruppe oder keine ffv6_additional_networks gibt.
Mit diesen Änderungen laufen sie zumindest durch.

Unabhängig davon sieht die erzeugte bird-Konfiguration jedoch seit 984b9e9f830ce87bb015ef94fb06731e95074c82 nicht so aus, als würde sie für Nicht-AS-Router funktionieren. Ich habe leider zu wenig Ahnung von bird und auch kein Test-Gateway, um das näher untersuchen zu können.