### PR TITLE
unattended_upgrades: Sofort /usr/lib/apt/apt.systemd.daily ausführen

### DIFF
--- a/unattended_upgrades/handlers/main.yml
+++ b/unattended_upgrades/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: run apt.systemd.daily
+  command: "/usr/lib/apt/apt.systemd.daily"

--- a/unattended_upgrades/tasks/main.yml
+++ b/unattended_upgrades/tasks/main.yml
@@ -11,6 +11,7 @@
   template:
     src: 10periodic.j2
     dest: /etc/apt/apt.conf.d/10periodic
+  notify: run apt.systemd.daily
 
 - name: Configure unattended upgrades on Debian
   template:


### PR DESCRIPTION
Nach Einschalten von unattended-upgrades gleich /usr/lib/apt/apt.systemd.daily ausführen.

Das Monitoring prüft, ob die Datei /var/lib/apt/periodic/upgrade-stamp existiert.
Bei neu installierten Servern gibt es einen Alert, weil diese Datei fehlt, bis /usr/lib/apt/apt.systemd.daily ausgeführt wurde.