### PR TITLE
nrpe: Rolle für Debian >10 anpassen

### DIFF
--- a/nrpe/tasks/main.yml
+++ b/nrpe/tasks/main.yml
@@ -12,6 +12,13 @@
   package:
     name: nagios-plugins-standard
     state: latest
+  when: (ansible_distribution == 'Debian' and ansible_distribution_version < '11')
+
+- name: Install Nagios Plugins
+  package:
+    name: monitoring-plugins-standard
+    state: latest
+  when: not (ansible_distribution == 'Debian' and ansible_distribution_version < '11')
 
 - name: Install bc
   package:


### PR DESCRIPTION
Paket "nagios-plugins-standard" wurde umbenannt zu "monitoring-plugins-standard"